### PR TITLE
fix: upgrade twilio from 5.13.1 to 6.0.0 (breaking)

### DIFF
--- a/packages/twilio/package.json
+++ b/packages/twilio/package.json
@@ -30,6 +30,9 @@
     "notifications",
     "messaging"
   ],
+  "engines": {
+    "node": ">=20"
+  },
   "author": "",
   "license": "MIT",
   "dependencies": {

--- a/packages/twilio/package.json
+++ b/packages/twilio/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "dependencies": {
     "@sendgrid/mail": "^8.1.6",
-    "twilio": "^5.13.1"
+    "twilio": "^6.0.0"
   },
   "peerDependencies": {
     "airhorn": "workspace:^"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: workspace:^
         version: link:../airhorn
       twilio:
-        specifier: ^5.13.1
-        version: 5.13.1
+        specifier: ^6.0.0
+        version: 6.0.0
 
 packages:
 
@@ -2983,9 +2983,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  twilio@5.13.1:
-    resolution: {integrity: sha512-sT+PkhptF4Mf7t8eXFFvPQx4w5VHnBIPXbltGPMFRe+R2GxfRdMuFbuNA/cEm0aQR6LFQOn33+fhClg+TjRVqQ==}
-    engines: {node: '>=14.0'}
+  twilio@6.0.0:
+    resolution: {integrity: sha512-MAie5DJ3KLpcKlDaYtNzsKMQXcCi+YHWKvZjuSpm27vJAO/l8PanJA0LkkJ03sbh+Kwe5NeL0Q2+y6IjNUYeUA==}
+    engines: {node: '>=20.0.0'}
 
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
@@ -6829,7 +6829,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  twilio@5.13.1:
+  twilio@6.0.0:
     dependencies:
       axios: 1.14.0
       dayjs: 1.11.20


### PR DESCRIPTION
## Summary

- `twilio`: 5.13.1 → 6.0.0 (major/breaking) in `packages/twilio`

### Breaking changes addressed

The only breaking change in twilio v6 is raising the minimum Node.js requirement from `>=14` to `>=20`. This project already targets Node 20, 22, and 24 in its test matrix, so no code changes are required.

All existing APIs (`messages.create()`, client initialization, TypeScript types) are unchanged between v5 and v6 per the [official upgrade guide](https://github.com/twilio/twilio-node/blob/main/UPGRADE.md).

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm test` passes across all packages (80/80 airhorn, 23/23 aws, 16/16 twilio, 25/25 azure)

https://claude.ai/code/session_01NKipxPS1SskaJ3MM4a8Bk5

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKipxPS1SskaJ3MM4a8Bk5)_