### PR TITLE
@airhornjs/azure - fix: upgrade @azure/communication-sms to 1.2.0-beta.4

### DIFF
--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@azure/communication-email": "^1.1.0",
-    "@azure/communication-sms": "^1.1.0",
+    "@azure/communication-sms": "1.2.0-beta.4",
     "@azure/notification-hubs": "^2.0.2"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       '@azure/communication-sms':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: 1.2.0-beta.4
+        version: 1.2.0-beta.4
       '@azure/notification-hubs':
         specifier: ^2.0.2
         version: 2.0.2
@@ -279,10 +279,6 @@ packages:
     resolution: {integrity: sha512-EHaOXW0RYDKS5CFffnixdyRPak5ytiCtU7uXDcP/uiY+A6jFRwNGzzJBiznkCzvi5EYpY+YWinieqHb0oY916A==}
     engines: {node: '>=20.0.0'}
 
-  '@azure/abort-controller@1.1.0':
-    resolution: {integrity: sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==}
-    engines: {node: '>=12.0.0'}
-
   '@azure/abort-controller@2.1.2':
     resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
     engines: {node: '>=18.0.0'}
@@ -295,8 +291,8 @@ packages:
     resolution: {integrity: sha512-n9ATpXyxb4MIhEp/Vtv5BU8GdUZH0vYpm/1pKXVu9AeiQ78MG3OIaiQQ2PmQfA0XPdTx5/g+tUxkwVuD6U4u4w==}
     engines: {node: '>=20.0.0'}
 
-  '@azure/communication-sms@1.1.0':
-    resolution: {integrity: sha512-mpyCIf9Kqf9yx2KPckPGbK/RJKvJK63plEyalBG4A0PfDpr5i02ChySTPCn72Jjn7jC3POBJ1L0fSTvjZdQMzw==}
+  '@azure/communication-sms@1.2.0-beta.4':
+    resolution: {integrity: sha512-QqYvmxE13Met66axBf6U/uLfT2zmAQUziTeTEUzTGqFbLkfrusTEP1sah7zVx60ZAGSP+pAoyCycuoaoYHNFhQ==}
     engines: {node: '>=18.0.0'}
 
   '@azure/core-auth@1.10.0':
@@ -3042,10 +3038,6 @@ packages:
     resolution: {integrity: sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA==}
     engines: {node: '>=18'}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    hasBin: true
-
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
@@ -3683,10 +3675,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/abort-controller@1.1.0':
-    dependencies:
-      tslib: 2.8.1
-
   '@azure/abort-controller@2.1.2':
     dependencies:
       tslib: 2.8.1
@@ -3719,18 +3707,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/communication-sms@1.1.0':
+  '@azure/communication-sms@1.2.0-beta.4':
     dependencies:
-      '@azure/abort-controller': 1.1.0
+      '@azure/abort-controller': 2.1.2
       '@azure/communication-common': 2.4.0
       '@azure/core-auth': 1.10.1
       '@azure/core-client': 1.10.1
       '@azure/core-rest-pipeline': 1.23.0
       '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
       '@azure/logger': 1.3.0
       events: 3.3.0
       tslib: 2.8.1
-      uuid: 8.3.2
     transitivePeerDependencies:
       - supports-color
 
@@ -6936,8 +6924,6 @@ snapshots:
       pupa: 3.3.0
       semver: 7.7.4
       xdg-basedir: 5.1.0
-
-  uuid@8.3.2: {}
 
   vfile-location@5.0.3:
     dependencies:


### PR DESCRIPTION
## Summary

- Upgrades `@azure/communication-sms` from `1.1.0` → `1.2.0-beta.4`
- Azure has set the `latest` dist-tag to this beta, making it the recommended version

## Changes in 1.2.0-beta.4 (all additive, no breaking changes)

- **beta.4**: MessagingConnect support (apiKey, partner fields in SmsSendOptions)
- **beta.3**: Fixed Opt Out Remove action
- **beta.2**: Opt Out Management API (opt-in, opt-out, check status)
- **beta.1**: `DeliveryReportTimeoutInSeconds` added to `SmsSendOptions`

No changes needed to existing `SmsClient` usage in `packages/azure/src/index.ts`.

## Test plan

- [x] `pnpm test` passes across all packages
- [x] All 25 tests in `@airhornjs/azure` pass with 100% statement/function/line coverage

https://claude.ai/code/session_01NTjZJqEfdoYXWQMKrjXe8C

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTjZJqEfdoYXWQMKrjXe8C)_