### PR TITLE
feat: Migrate to pnpm 11 with corepack and Node 22/24/26 CI

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -17,25 +17,27 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
         node-version: 24
 
     - name: Install Dependencies
-      run: npm install -g pnpm && pnpm install
+      run: pnpm install --frozen-lockfile
 
-    - name: Build    
+    - name: Build
       run: pnpm build
 
     - name: Testing
       env:
         FIREBASE_CERT: ${{ secrets.FIREBASE_CERT }}
       run: pnpm test
-      
+
     - name: Code Coverage
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_KEY }}
         files: ./packages/**/coverage/*.lcov
-

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -17,18 +17,20 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    # Test
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
         node-version: 24
 
-    - name: Install Dependencies  
-      run: npm install -g pnpm && pnpm install
+    - name: Install Dependencies
+      run: pnpm install --frozen-lockfile
 
-    - name: Build Website
+    - name: Build
       run: pnpm build
-    
+
     - name: Build Website
       run: pnpm website:build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,15 +15,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 24
 
       - name: Install Dependencies
-        run: npm install -g pnpm && pnpm install
+        run: pnpm install --frozen-lockfile
 
-      - name: Build    
+      - name: Build
         run: pnpm build
 
       - name: Testing
@@ -31,21 +34,17 @@ jobs:
 
       - name: create npmrc
         run: |
-         echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-         echo "always-auth=true" >> ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+          echo "always-auth=true" >> ~/.npmrc
 
       - name: Publish airhorn
-        run: |
-         pnpm publish:airhorn
-      
+        run: pnpm publish:airhorn
+
       - name: Publish @airhornjs/aws
-        run: |
-         pnpm publish:aws
+        run: pnpm publish:aws
 
       - name: Publish @airhornjs/azure
-        run: |
-         pnpm publish:azure
+        run: pnpm publish:azure
 
       - name: Publish @airhornjs/twilio
-        run: |
-         pnpm publish:twilio 
+        run: pnpm publish:twilio

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,23 +14,25 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['20', '22', '24']
+        node-version: ['22', '24', '26']
 
     steps:
     - uses: actions/checkout@v4
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 
     - name: Install Dependencies
-      run: npm install -g pnpm && pnpm install
-      
-    - name: Build    
+      run: pnpm install --frozen-lockfile
+
+    - name: Build
       run: pnpm build
 
     - name: Testing
       env:
         FIREBASE_CERT: ${{ secrets.FIREBASE_CERT }}
       run: pnpm test
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ pnpm test             # Runs: biome lint + vitest with coverage
 1. Make your changes in `src/` and `test/` within the relevant package
 2. Run `pnpm test` from the repo root to lint, test, and check coverage across all packages
 3. Target **100% code coverage** — every new or changed line must be tested
-4. All tests must pass on Node.js 20, 22, and 24
+4. All tests must pass on Node.js 22, 24, and 26
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Airhorn makes it easy to send SMS, SMTP, Webhooks, and mobile push notifications
 - Robust (6+ template formats) templating via [ecto](https://github.com/jaredwray/ecto)
 - Easily build your own provider with minimal effort via `AirhornProvider` interface.
 - Statistics tracking for send successes, failures, and execution times (instance only).
-- ESM and Typescript based supporting Nodejs 20+
+- ESM and Typescript based supporting Nodejs 22+
 - Maintained on a regular basis with updates and improvements.
 
 # Getting Started

--- a/package.json
+++ b/package.json
@@ -30,5 +30,6 @@
     "tsx": "^4.21.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"
-  }
+  },
+  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1"
 }

--- a/packages/airhorn/package.json
+++ b/packages/airhorn/package.json
@@ -11,7 +11,7 @@
     }
   },
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=22.0.0"
   },
   "repository": "https://github.com/jaredwray/airhorn.git",
   "author": "Jared Wray <me@jaredwray.com>",

--- a/packages/twilio/package.json
+++ b/packages/twilio/package.json
@@ -33,7 +33,7 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@sendgrid/mail": "^8.1.6",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,5 @@ minimumReleaseAgeExclude:
   - hookified
 packages:
   - packages/*
-onlyBuiltDependencies:
-  - '@biomejs/biome'
-  - esbuild
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Summary

Migrates the monorepo to **pnpm 11** (`11.5.0`), pins it via the `packageManager` field (corepack standard), moves CI installs to `pnpm/action-setup`, and shifts the test matrix to **Node.js 22, 24, 26**.

Verified locally with pnpm `11.5.0`: `pnpm install --frozen-lockfile`, `pnpm build`, and `pnpm test` all pass (144 tests, 100% coverage across all four packages). The `pnpm-lock.yaml` is unchanged — pnpm 11 reads the existing v9.0 lockfile natively.

## Changes

**pnpm 11 + corepack**
- `package.json`: added `"packageManager": "pnpm@11.5.0+sha512…"` (with integrity hash). This is the single source of truth — corepack honors it for local dev, and `pnpm/action-setup` reads it in CI.
- `pnpm-workspace.yaml`: pnpm 11 **removed** `onlyBuiltDependencies`/`neverBuiltDependencies`/`ignoredBuiltDependencies` ([release notes](https://pnpm.io/blog/releases/11.0)) and replaced them with the `allowBuilds` map. Without this, `pnpm build` now hard-fails with `ERR_PNPM_IGNORED_BUILDS`. Replaced with:
  ```yaml
  allowBuilds:
    esbuild: true
  ```
  `esbuild` keeps its `postinstall`; `@biomejs/biome` 2.x no longer ships a build script (it uses optional platform-binary deps), so it's dropped from the approval list.

**CI workflows** (`tests`, `code-coverage`, `release`, `deploy-site`)
- Install pnpm via `pnpm/action-setup@v4` (auto-detects the version from the `packageManager` field) instead of `npm install -g pnpm`.
- Install step is now `pnpm install --frozen-lockfile` (no `cache: 'pnpm'`).
- `tests.yml` matrix: `['20', '22', '24']` → `['22', '24', '26']`. Single-version jobs stay on Node 24 (Active LTS).
- Minor cleanups: trailing whitespace, missing final newlines, and a duplicate `Build Website` step name in `deploy-site.yml`.

**Supporting updates**
- `packages/airhorn` & `packages/twilio` `engines.node`: `>=20.x` → `>=22.0.0` (Node 20 reached EOL April 2026 and is dropped from CI).
- Docs: `AGENTS.md` (Node 22/24/26) and `README.md` (Nodejs 22+).

## Note for reviewer

Bumping `engines.node` to `>=22.0.0` is the one consumer-facing change — it aligns published metadata with the dropped Node 20. Happy to revert that part if you'd prefer to keep a wider support range while still testing on 22/24/26.

https://claude.ai/code/session_014bNbCDKH1YTEWB6LWPhY1t

---
_Generated by [Claude Code](https://claude.ai/code/session_014bNbCDKH1YTEWB6LWPhY1t)_