### PR TITLE
mono - chore: upgrade GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
 
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 24
 
@@ -37,7 +37,7 @@ jobs:
       run: pnpm test
 
     - name: Code Coverage
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_KEY }}
         files: ./packages/**/coverage/*.lcov

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -15,13 +15,13 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
 
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 24
 
@@ -35,7 +35,7 @@ jobs:
       run: pnpm website:build
 
     - name: Publish to Cloudflare Pages
-      uses: cloudflare/wrangler-action@v3
+      uses: cloudflare/wrangler-action@v4
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         command: pages deploy site/dist --project-name=airhorn --branch=main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,12 +17,12 @@ jobs:
         node-version: ['22', '24', '26']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
## GitHub Actions pin sweep

Bumps workflow `uses:` pins to their latest major versions (floating major tags, matching the repo's existing convention).

| Action | From | To | Notes |
|---|---|---|---|
| `actions/checkout` | v4 | **v6** | Node-runtime major; basic checkout usage unaffected |
| `actions/setup-node` | v4 | **v6** | Only `node-version` used; unaffected |
| `pnpm/action-setup` | v4 | **v6** | No `version:` input — reads `packageManager: pnpm@11.5.0` (corepack mode), same in v6 |
| `codecov/codecov-action` | v5 | **v6** | Verified `token` + `files` inputs still exist in v6's `action.yml` |
| `cloudflare/wrangler-action` | v3 | **v4** | Defaults Wrangler to v4; `pages deploy` syntax unchanged |
| `github/codeql-action/*` | v3 | _v3_ | **Unchanged** — already the latest major (the v2.25.x tags are the CodeQL CLI bundle, not the action major) |

### Files touched
`tests.yml`, `code-coverage.yml`, `codeql.yml`, `deploy-site.yml`, `release.yml` — only `@vN` tokens on `uses:` lines changed (15 insertions / 15 deletions). All five validated as well-formed YAML.

### Validation
- The PR-triggered workflows (`tests`, `code-coverage`, `codeql`) exercise the **checkout / setup-node / pnpm-action-setup / codecov** bumps directly on this PR — so green CI here validates them.
- `wrangler-action@v4` runs only in `deploy-site` (on `release`), and `release.yml` runs only on release — these reuse the same checkout/setup-node/pnpm-action-setup actions validated above; the only release-only delta is the Wrangler v3→v4 default, where the `pages deploy` invocation is unchanged.

Final item of the dependency-management **dev phase**. Next: the runtime phase (`cacheable`, `ecto`, `twilio`, AWS SDK pair, `@azure/notification-hubs`, and `hookified` 2→3 major).

---
_Generated by [Claude Code](https://claude.ai/code/session_011St5s1vnjUdNRuihmeQsbB)_