### PR TITLE
@airhornjs/azure: upgrade @azure/notification-hubs to 2.1.0

### DIFF
--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@azure/communication-email": "^1.1.0",
     "@azure/communication-sms": "1.2.0-beta.4",
-    "@azure/notification-hubs": "^2.0.2"
+    "@azure/notification-hubs": "^2.1.0"
   },
   "peerDependencies": {
     "airhorn": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: 1.2.0-beta.4
         version: 1.2.0-beta.4
       '@azure/notification-hubs':
-        specifier: ^2.0.2
-        version: 2.0.2
+        specifier: ^2.1.0
+        version: 2.1.0
       airhorn:
         specifier: workspace:*
         version: link:../airhorn
@@ -235,10 +235,6 @@ packages:
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
 
-  '@azure-rest/core-client@2.5.0':
-    resolution: {integrity: sha512-KMVIPxG6ygcQ1M2hKHahF7eddKejYsWTjoLIfTWiqnaj42dBkYzj4+S8rK9xxmlOaEHKZHcMrRbm0NfN4kgwHw==}
-    engines: {node: '>=20.0.0'}
-
   '@azure-rest/core-client@2.5.1':
     resolution: {integrity: sha512-EHaOXW0RYDKS5CFffnixdyRPak5ytiCtU7uXDcP/uiY+A6jFRwNGzzJBiznkCzvi5EYpY+YWinieqHb0oY916A==}
     engines: {node: '>=20.0.0'}
@@ -319,8 +315,8 @@ packages:
     resolution: {integrity: sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==}
     engines: {node: '>=20.0.0'}
 
-  '@azure/notification-hubs@2.0.2':
-    resolution: {integrity: sha512-BGrBEp7vT3wO0bQg5CNzQKPa6BGdONVdkWmyf1Pb1rxH5MK7q7jWPqS5eJB8uicCtjd9ZmMWvQ47YNO3hgCEtA==}
+  '@azure/notification-hubs@2.1.0':
+    resolution: {integrity: sha512-TNwOM7osEt3J+fe3egAG5SONumeNzuzxu40UaXbdE5Mr4MCY9pvgmV/kcLrJEdbniBvophiuH2b6LkFBCrESYQ==}
     engines: {node: '>=20.0.0'}
 
   '@babel/helper-string-parser@7.27.1':
@@ -1788,10 +1784,6 @@ packages:
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
 
-  fast-xml-parser@5.2.5:
-    resolution: {integrity: sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==}
-    hasBin: true
-
   fast-xml-parser@5.7.3:
     resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
@@ -2807,9 +2799,6 @@ packages:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
-  strnum@2.1.1:
-    resolution: {integrity: sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==}
-
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
 
@@ -3391,17 +3380,6 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.4': {}
 
-  '@azure-rest/core-client@2.5.0':
-    dependencies:
-      '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.0
-      '@azure/core-rest-pipeline': 1.22.0
-      '@azure/core-tracing': 1.3.0
-      '@typespec/ts-http-runtime': 0.3.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@azure-rest/core-client@2.5.1':
     dependencies:
       '@azure/abort-controller': 2.1.2
@@ -3512,7 +3490,7 @@ snapshots:
   '@azure/core-lro@3.3.0':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@azure/core-util': 1.13.0
+      '@azure/core-util': 1.13.1
       '@azure/logger': 1.3.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -3572,7 +3550,7 @@ snapshots:
 
   '@azure/core-xml@1.5.0':
     dependencies:
-      fast-xml-parser: 5.2.5
+      fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
   '@azure/logger@1.3.0':
@@ -3582,16 +3560,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/notification-hubs@2.0.2':
+  '@azure/notification-hubs@2.1.0':
     dependencies:
-      '@azure-rest/core-client': 2.5.0
+      '@azure-rest/core-client': 2.5.1
       '@azure/abort-controller': 2.1.2
-      '@azure/core-auth': 1.10.0
+      '@azure/core-auth': 1.10.1
       '@azure/core-lro': 3.3.0
       '@azure/core-paging': 1.6.2
-      '@azure/core-rest-pipeline': 1.22.0
-      '@azure/core-tracing': 1.3.0
-      '@azure/core-util': 1.13.0
+      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
       '@azure/core-xml': 1.5.0
       '@azure/logger': 1.3.0
       tslib: 2.8.1
@@ -4801,10 +4779,6 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.5.0
       xml-naming: 0.1.0
-
-  fast-xml-parser@5.2.5:
-    dependencies:
-      strnum: 2.1.1
 
   fast-xml-parser@5.7.3:
     dependencies:
@@ -6297,8 +6271,6 @@ snapshots:
       ansi-regex: 6.2.2
 
   strip-json-comments@2.0.1: {}
-
-  strnum@2.1.1: {}
 
   strnum@2.2.3: {}
 


### PR DESCRIPTION
## Runtime phase — `@airhornjs/azure`

| Package | From | To |
|---|---|---|
| `@azure/notification-hubs` | 2.0.2 | **2.1.0** |

Minor version bump — no API changes affecting our usage. (The other azure deps — `@azure/communication-email` `^1.1.0` and the pinned `@azure/communication-sms` `1.2.0-beta.4` — are already current and untouched.)

### Scope
- Only `packages/azure/package.json` (the one spec) and `pnpm-lock.yaml` changed (`+1 / −4` packages). No other direct runtime dependencies were touched.

### Verification (local, Node 22 + pnpm 11.5.0)
- `pnpm build` — ✅ all packages
- `pnpm test` — ✅ **144 tests pass** (azure provider **25/25** at 100% coverage; airhorn 80, aws 23, twilio 16).

Runtime phase PR #2. Next: `twilio` 6.0.2, then the airhorn-core `cacheable`/`ecto` patches, and finally `hookified` 2→3 (major).

---
_Generated by [Claude Code](https://claude.ai/code/session_011St5s1vnjUdNRuihmeQsbB)_