### PR TITLE
@airhornjs/twilio: upgrade twilio to 6.0.2

### DIFF
--- a/packages/twilio/package.json
+++ b/packages/twilio/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@sendgrid/mail": "^8.1.6",
-    "twilio": "^6.0.0"
+    "twilio": "^6.0.2"
   },
   "peerDependencies": {
     "airhorn": "workspace:^"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: workspace:^
         version: link:../airhorn
       twilio:
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.0.2
+        version: 6.0.2
 
 packages:
 
@@ -2899,8 +2899,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  twilio@6.0.0:
-    resolution: {integrity: sha512-MAie5DJ3KLpcKlDaYtNzsKMQXcCi+YHWKvZjuSpm27vJAO/l8PanJA0LkkJ03sbh+Kwe5NeL0Q2+y6IjNUYeUA==}
+  twilio@6.0.2:
+    resolution: {integrity: sha512-RN3TZxUtxLz2HBZVt62+LdZxQbrMVgYKtuzLgwmO7nqKvR+gQS5mCackD9hf4Y7MmoK/bX7tCm7kaJC8kC8zFA==}
     engines: {node: '>=20.0.0'}
 
   type-fest@4.41.0:
@@ -6375,7 +6375,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  twilio@6.0.0:
+  twilio@6.0.2:
     dependencies:
       axios: 1.14.0
       dayjs: 1.11.20


### PR DESCRIPTION
## Runtime phase — `@airhornjs/twilio`

| Package | From | To |
|---|---|---|
| `twilio` | 6.0.0 | **6.0.2** |

Patch bump within the twilio v6 line — no API changes. (`@sendgrid/mail` `^8.1.6` is already current and untouched.)

### Scope
- Only `packages/twilio/package.json` (the one spec) and `pnpm-lock.yaml` changed (`+1 / −1`). No other direct runtime dependencies were touched.

### Verification (local, Node 22 + pnpm 11.5.0)
- `pnpm build` — ✅ all packages
- `pnpm test` — ✅ **144 tests pass** (twilio provider **16/16** at 100% coverage; airhorn 80, aws 23, azure 25).

Runtime phase PR #3. Next: the airhorn-core `cacheable`/`ecto` patches, then `hookified` 2→3 (major).

---
_Generated by [Claude Code](https://claude.ai/code/session_011St5s1vnjUdNRuihmeQsbB)_