### PR TITLE
airhorn: upgrade hookified to 3.0.0

### DIFF
--- a/packages/airhorn/package.json
+++ b/packages/airhorn/package.json
@@ -11,7 +11,7 @@
     }
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.18.0"
   },
   "repository": "https://github.com/jaredwray/airhorn.git",
   "author": "Jared Wray <me@jaredwray.com>",
@@ -29,7 +29,7 @@
   "dependencies": {
     "cacheable": "^2.3.5",
     "ecto": "^4.8.7",
-    "hookified": "^2.2.0",
+    "hookified": "^3.0.0",
     "writr": "^6.1.2"
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^4.8.7
         version: 4.8.7
       hookified:
-        specifier: ^2.2.0
-        version: 2.2.0
+        specifier: ^3.0.0
+        version: 3.0.0
       writr:
         specifier: ^6.1.2
         version: 6.1.2
@@ -1938,6 +1938,10 @@ packages:
 
   hookified@2.2.0:
     resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
+
+  hookified@3.0.0:
+    resolution: {integrity: sha512-x+jzDjd9CWxdgl6u/K4pjnvw7PZx6ZSpiPGAV43uXlJiJy7r2jIEUxxU1Cv7+rwy1GK5Qt5S+Jp7n81DpcUvTA==}
+    engines: {node: '>=22.18.0'}
 
   html-dom-parser@7.0.1:
     resolution: {integrity: sha512-loRBDTCY/05/jAC63J1X9ID+xjRucmpLkIcQO0IRbOubBo5ucnpUpyXXob9UMXOskMZlu7KPsDP/2KOMelzJNA==}
@@ -4963,6 +4967,8 @@ snapshots:
   hookified@1.15.1: {}
 
   hookified@2.2.0: {}
+
+  hookified@3.0.0: {}
 
   html-dom-parser@7.0.1:
     dependencies:


### PR DESCRIPTION
## airhorn core — `hookified` 2.2.0 → 3.0.0 (major)

`airhorn`'s core `Airhorn` class `extends Hookified`, so this major was reviewed carefully rather than relying on tests alone.

| Package | From | To |
|---|---|---|
| `hookified` | 2.2.0 | **3.0.0** |

### Breaking-change assessment
hookified v3's only documented breaking change is the **Node requirement**: drops Node 20, now `engines.node >=22.18.0` (v2 declared no engines). No API/method changes are documented.

### API compatibility — verified against the installed v3 type defs
`airhorn` uses a minimal slice of the Hookified API, all confirmed intact in v3 (`dist/node/index.d.ts`):
- `class Airhorn extends Hookified` → `Hookified` still exported ✅
- `this.emit(event, payload)` → `emit(event, ...args): boolean` ✅
- `await this.hook(name, payload)` → `hook<T>(event, ...args): Promise<void>` ✅

No source changes were needed in `airhorn`.

### Engines
Because v3 introduces a `>=22.18.0` floor that exceeded airhorn's declared `>=22.0.0`, this PR also raises **airhorn's** `engines.node` to `>=22.18.0` to keep the published metadata accurate with its new hard dependency. (CI already runs Node 22-latest/24/26; no `engine-strict` is set, so installs are unaffected.)

### Scope
- Only `packages/airhorn/package.json` (`hookified` spec + `engines`) and `pnpm-lock.yaml` (`+1` package: `hookified@3.0.0`). No other dependencies touched.

### Verification (local, Node 22.22.2 + pnpm 11.5.0)
- `pnpm build` — ✅ all packages
- `pnpm test` — ✅ **144 tests pass** (airhorn core **80/80** at 100% coverage; aws 23, azure 25, twilio 16).

🏁 **Final PR of the dependency-management pass** — completes the runtime phase (and the whole sweep: dev phase + all runtime deps).

---
_Generated by [Claude Code](https://claude.ai/code/session_011St5s1vnjUdNRuihmeQsbB)_