### PR TITLE
release: v7.0.0 (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airhorn-mono",
-  "version": "6.0.1",
+  "version": "7.0.0",
   "description": "Cloud Notification Library",
   "repository": "https://github.com/jaredwray/airhorn.git",
   "author": "Jared Wray <me@jaredwray.com>",

--- a/packages/airhorn/README.md
+++ b/packages/airhorn/README.md
@@ -59,6 +59,7 @@
 - [Hooks](#hooks)
 - [Emitting Events](#emitting-events)
 - [Load Template Helper](#load-template-helper)
+- [Migration to v7](#migration-to-v7)
 - [Migration to v6](#migration-to-v6)
 - [Core Supported Providers](#core-supported-providers)
 - [Third Party Providers](#third-party-providers)
@@ -732,6 +733,45 @@ const airhorn = new Airhorn({
 ```
 
 Use one of the built in providers as a reference such as `@airhornjs/twilio`.
+
+# Migration to v7
+
+Airhorn v7 raises the minimum Node.js version to **`>=22.18.0`** and upgrades to [Hookified v3](https://hookified.org). Hookified v3 contains **no API changes** — the hooks API is identical to v6 — so for most users the only required change is updating the Node.js runtime.
+
+## Breaking Changes
+
+### Node.js >=22.18.0 required
+
+The minimum supported Node.js version is now **22.18.0** (previously `>=20`). Node.js 20 reached end-of-life in April 2026, and [Hookified v3](https://hookified.org) — which `Airhorn` extends — requires `>=22.18.0`.
+
+```jsonc
+// package.json (airhorn)
+"engines": {
+	"node": ">=22.18.0"
+}
+```
+
+**Migration:** Upgrade your runtime to Node.js 22 LTS (>= 22.18.0) or Node.js 24+. No code changes are required.
+
+### Hookified upgraded to v3 (no API changes)
+
+`Airhorn` extends [Hookified](https://hookified.org), which was upgraded from v2 to v3. Hookified v3's only breaking change is the Node.js requirement above — `onHook`, `removeHook`, `removeHookById`, `getHooks`, and `throwOnErrors` all behave exactly as they did in v6:
+
+```typescript
+// Unchanged from v6 — still works in v7
+airhorn.onHook({
+	id: "my-hook",
+	event: "before:Send",
+	handler: async (data) => {},
+});
+```
+
+If you already migrated your hooks from v5 to v6, upgrading from v6 to v7 requires no hooks-related code changes.
+
+## Migration Checklist
+
+- [ ] Upgrade your runtime to Node.js >= 22.18.0 (Node 22 LTS or Node 24+)
+- [ ] No code changes required — the hooks API is unchanged from v6
 
 # Migration to v6
 

--- a/packages/airhorn/package.json
+++ b/packages/airhorn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airhorn",
-  "version": "6.0.1",
+  "version": "7.0.0",
   "description": "Cloud Notification Library",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airhornjs/aws",
-  "version": "6.0.1",
+  "version": "7.0.0",
   "description": "AWS SNS and SES provider for Airhorn",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airhornjs/azure",
-  "version": "6.0.1",
+  "version": "7.0.0",
   "description": "Azure provider for Airhorn",
   "license": "MIT",
   "author": "Jared Wray <me@jaredwray.com>",

--- a/packages/twilio/package.json
+++ b/packages/twilio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airhornjs/twilio",
-  "version": "6.0.1",
+  "version": "7.0.0",
   "description": "Twilio SMS and SendGrid Email provider for Airhorn notification system",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release summary

Releasing all 4 packages in lockstep: **airhorn@7.0.0**, **@airhornjs/aws@7.0.0**, **@airhornjs/azure@7.0.0**, **@airhornjs/twilio@7.0.0** (major). airhorn requires Node >=22.18.0 and moves to hookified v3; the Twilio provider moves to twilio v6.

> Rebased onto `main` after #608 (npm Trusted Publishing / provenance) merged — that PR is now part of this release window. The version bump still touches only the 5 `version` fields and conflicts cleanly.

## Packages

| Package | Current | New | Bump | Rationale | Commits |
|---|---|---|---|---|---|
| `airhorn` | `6.0.1` | `7.0.0` | **major** | hookified 2→3 (public base class `Airhorn extends Hookified`); Node floor `>=20` → `>=22.18.0` | 13 |
| `@airhornjs/twilio` | `6.0.1` | `7.0.0` | **major** | twilio 5→6 (breaking); new Node floor `>=22.0.0` | 11 |
| `@airhornjs/aws` | `6.0.1` | `7.0.0` | **major** | lockstep (own changes non-breaking: aws-sdk 3.1024→3.1057) | 8 |
| `@airhornjs/azure` | `6.0.1` | `7.0.0` | **major** | lockstep (own changes non-breaking: azure SDK minors) | 7 |
| `airhorn-mono` (root) | `6.0.1` | `7.0.0` | _private_ | not published; version synced for lockstep | 24 |

This is a fixed/locked-version monorepo — `release.yml` publishes all packages together and `scripts/version-sync.ts` drives every manifest from the root version, so the highest bump (major) applies to every package.

## airhorn v7.0.0 — 2026-06-02

Major release: airhorn requires Node >=22.18.0 and moves to hookified v3; the Twilio provider moves to twilio v6.

### ⚠ BREAKING CHANGES
- **airhorn** now requires Node.js `>=22.18.0` (was `>=20`) and upgrades `hookified` to v3 (#605, #588)
  Migration: upgrade your runtime to Node 22.18.0+. `Airhorn` extends `Hookified`, so if you rely on its hook/event API surface, review the hookified v3 release notes.
- **@airhornjs/twilio** now requires Node.js `>=22.0.0` (no floor before) and upgrades the `twilio` SDK to v6 (#590, #603)
  Migration: upgrade to Node 22+. The provider's own API is unchanged; if you also import `twilio` directly, follow the twilio v6 migration guide.

### Dependencies
**airhorn**
- `hookified` `^2.1.1` → `^3.0.0` (#588, #605)
- `cacheable` `^2.3.4` → `^2.3.5`, `ecto` `^4.8.3` → `^4.8.7` (#587, #604)
- `writr` `^6.1.1` → `^6.1.2` (#589)

**@airhornjs/aws**
- `@aws-sdk/client-ses` & `@aws-sdk/client-sns` `^3.1024.0` → `^3.1057.0` (#586, #591, #601)

**@airhornjs/azure**
- `@azure/notification-hubs` `^2.0.2` → `^2.1.0` (#602)
- `@azure/communication-sms` `^1.1.0` → `1.2.0-beta.4` (#592)

**@airhornjs/twilio**
- `twilio` `^5.13.1` → `^6.0.2` (#590, #603)

### Internal
- Publish via npm Trusted Publishing (OIDC) with signed provenance; add `repository` metadata required for provenance (#608)
- Migrate build tooling from tsup to tsdown (#606)
- Migrate to pnpm 11 with corepack and Node 22/24/26 CI (#597)
- Upgrade typescript to 6.0.3 (#585), docula to 2.0.0 (#584, #599), GitHub Actions to latest majors (#600)
- Dev-dependency upgrades: biome, vitest, tsx, @types/node, and other code-quality tools (#581, #582, #583, #596, #598)

### Contributors
- @jaredwray (24 PRs)

### Full List of Changes
- version sync by @jaredwray in 70c31cd
- mono - fix: upgrade vitest and @vitest/coverage-v8 from 4.1.2 to 4.1.5 by @jaredwray in #581
- mono - fix: upgrade @biomejs/biome from 2.4.10 to 2.4.13 by @jaredwray in #582
- airhorn - fix: upgrade hookified from 2.1.1 to 2.2.0 by @jaredwray in #588
- mono - fix: pin @types/node to Node 24 LTS (from ^25.5.2 to ^24.12.2) by @jaredwray in #583
- airhorn - fix: upgrade writr from 6.1.1 to 6.1.2 by @jaredwray in #589
- airhorn - fix: upgrade ecto from 4.8.3 to 4.8.4 by @jaredwray in #587
- @airhornjs/aws - fix: upgrade @aws-sdk/client-ses and @aws-sdk/client-sns from 3.1024.0 to 3.1039.0 by @jaredwray in #586
- @airhornjs/twilio - fix: upgrade twilio from 5.13.1 to 6.0.0 (breaking) by @jaredwray in #590
- mono - fix: upgrade typescript from 5.9.3 to 6.0.3 (breaking) by @jaredwray in #585
- mono - fix: upgrade docula from 1.12.0 to 1.14.0 by @jaredwray in #584
- @airhornjs/azure - fix: upgrade @azure/communication-sms to 1.2.0-beta.4 by @jaredwray in #592
- @airhornjs/aws - fix: upgrade @aws-sdk/client-ses and @aws-sdk/client-sns to 3.1040.0 by @jaredwray in #591
- feat: Migrate to pnpm 11 with corepack and Node 22/24/26 CI by @jaredwray in #597
- mono - chore: upgrade code quality dependencies by @jaredwray in #596
- mono - chore: upgrade tsx to 4.22.3 by @jaredwray in #598
- mono - chore: upgrade docula to 2.0.0 (major) by @jaredwray in #599
- mono - chore: upgrade GitHub Actions to latest major versions by @jaredwray in #600
- @airhornjs/aws: upgrade @aws-sdk/client-ses and @aws-sdk/client-sns to 3.1057.0 by @jaredwray in #601
- @airhornjs/azure: upgrade @azure/notification-hubs to 2.1.0 by @jaredwray in #602
- @airhornjs/twilio: upgrade twilio to 6.0.2 by @jaredwray in #603
- airhorn: upgrade cacheable to 2.3.5 and ecto to 4.8.7 by @jaredwray in #604
- airhorn: upgrade hookified to 3.0.0 by @jaredwray in #605
- chore: Migrate build tooling from tsup to tsdown by @jaredwray in #606
- ci: publish via npm Trusted Publishing (OIDC) with provenance by @jaredwray in #608

**Full diff:** https://github.com/jaredwray/airhorn/compare/v6.0.1...v7.0.0

## Verification
- [x] Rebased onto latest `main` (`64d318c`, includes #608) — clean, no conflicts
- [x] `pnpm install --frozen-lockfile` succeeds (lockfile unchanged — workspace cross-deps resolve by path)
- [x] `pnpm build` succeeds for all 4 packages
- [x] `pnpm test:ci` passes locally — 144 tests, 100% line coverage (airhorn 80, azure 25, aws 23, twilio 16)
- [x] No uncommitted changes outside the version bump

## Post-merge
Publishing now uses **npm Trusted Publishing (OIDC) with signed provenance** (changed in #608) — no `NPM_TOKEN`.

1. ⚠️ **One-time setup required before this release can publish:** on npmjs.com, configure a GitHub Actions **Trusted Publisher** for each of `airhorn`, `@airhornjs/aws`, `@airhornjs/azure`, `@airhornjs/twilio` → org/user `jaredwray`, repo `airhorn`, workflow `release.yml`, environment blank. OIDC publishing fails until this is set per package (see #608).
2. Merge this PR, then create a **GitHub Release at tag `v7.0.0`** ([`compare/v6.0.1...v7.0.0`](https://github.com/jaredwray/airhorn/compare/v6.0.1...v7.0.0)) using the notes above — `release.yml` builds, tests, and publishes all four packages to npm with provenance, and `deploy-site.yml` deploys the docs.