### PR TITLE
mono - chore: upgrade monorepo tooling (pnpm 11.9.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,5 @@
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   },
-  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1"
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A, tooling-only change; existing suite passes at 100%.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore — monorepo tooling upgrade (package manager).

## Summary
Upgrade the pinned pnpm package manager version.

## Versions
- `pnpm` (`packageManager`) `11.5.0` → `11.9.0`

## Tests
- [x] `pnpm build` passes
- [x] `pnpm test` passes (airhorn 80, aws 23, azure 25, twilio all green; coverage 100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYsLGvwRNPSQjZ81BDnD31)_