### PR TITLE
airhorn - chore: upgrade ecto (breaking)

### DIFF
--- a/packages/airhorn/package.json
+++ b/packages/airhorn/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "cacheable": "^2.5.0",
-    "ecto": "^4.8.7",
+    "ecto": "^5.0.0",
     "hookified": "^3.0.1",
     "writr": "^6.1.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^2.5.0
         version: 2.5.0
       ecto:
-        specifier: ^4.8.7
-        version: 4.8.7
+        specifier: ^5.0.0
+        version: 5.0.0
       hookified:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1505,8 +1505,17 @@ packages:
   ecto@4.8.7:
     resolution: {integrity: sha512-T3rANwJQsLIEXGRES/6FLPrbIGmVlLMj7aFoxyzPhVOT8yTPFnlWrJrx9x2XYU3DIq9no2ku/ij6v6vMN8aVaQ==}
 
+  ecto@5.0.0:
+    resolution: {integrity: sha512-uuoTfhPqp+ADz4vsBHrHq6zPq45G5ce7+0WOFrtwOwIUREX6AtsziVzCU4yJbVCA3oveKMlDrVt9j/JNSSiFVA==}
+    engines: {node: '>=22.18.0'}
+
   ejs@5.0.2:
     resolution: {integrity: sha512-IpbUaI/CAW86l3f+T8zN0iggSc0LmMZLcIW5eRVStLVNCoTXkE0YlncbbH50fp8Cl6zHIky0sW2uUbhBqGw0Jw==}
+    engines: {node: '>=0.12.18'}
+    hasBin: true
+
+  ejs@6.0.1:
+    resolution: {integrity: sha512-UaaM14yby8U3k02ihS1Bmj5Kz2d7CCQM1scxpgs4Mhkq8F1wR2gl3+Ts4h5Ne4Mnt7M9m4Dw7jsuMr3+xO4vZA==}
     engines: {node: '>=0.12.18'}
     hasBin: true
 
@@ -4326,7 +4335,24 @@ snapshots:
       - chokidar
       - supports-color
 
+  ecto@5.0.0:
+    dependencies:
+      '@jaredwray/fumanchu': 4.7.0
+      cacheable: 2.5.0
+      ejs: 6.0.1
+      hookified: 3.0.1
+      liquidjs: 10.27.0
+      nunjucks: 3.2.4
+      pug: 3.0.4
+      writr: 6.1.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - chokidar
+      - supports-color
+
   ejs@5.0.2: {}
+
+  ejs@6.0.1: {}
 
   emoji-regex@10.6.0: {}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A, dependency-only change; existing suite passes at 100%.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore — runtime dependency upgrade (major/breaking).

## Summary
Upgrade the `ecto` templating dependency in the `airhorn` package to its 5.0 major.

## Versions
- `ecto` `4.8.7` → `5.0.0` (major)

## Tests
- [x] `pnpm build` passes
- [x] `pnpm test` passes (airhorn 80 tests, 100% coverage)

## Breaking notes
ecto 5.0.0 is a major release, but the breaking changes are internal to ecto and do not affect airhorn:
- Raises its engine requirement to `node >=22.18.0`. airhorn already declares `engines.node ">=22.18.0"`, so this is already satisfied (CI runs Node 22/24/26).
- Bumps internal dependencies (`ejs` 5 → 6, `hookified` 2 → 3) and drops `ent`.

The public `Ecto` API airhorn consumes — the constructor `{ cache }`, the `cache` getter/setter, and `render(source, data)` — is unchanged, so no source changes were required. The email subject/content render path is covered by the existing test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYsLGvwRNPSQjZ81BDnD31)_