### PR TITLE
pingram - feat: add @airhornjs/pingram provider for SMS, Email, and Mobile Push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,3 +50,9 @@ jobs:
 
       - name: Publish @airhornjs/twilio
         run: pnpm publish:twilio
+
+      # Kept last: @airhornjs/pingram needs a one-time manual first publish
+      # before its npmjs.com trusted publisher can be configured, so a failure
+      # here must not block the packages above.
+      - name: Publish @airhornjs/pingram
+        run: pnpm publish:pingram

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Airhorn is a cloud-native notifications library providing a unified API for SMS, Email, Mobile Push, and Webhook delivery. This is a pnpm monorepo with four packages under `packages/`.
+Airhorn is a cloud-native notifications library providing a unified API for SMS, Email, Mobile Push, and Webhook delivery. This is a pnpm monorepo with five packages under `packages/`.
 
 ## Packages
 
@@ -10,6 +10,7 @@ Airhorn is a cloud-native notifications library providing a unified API for SMS,
 - `packages/twilio` — Twilio provider (`@airhornjs/twilio`)
 - `packages/aws` — AWS provider (`@airhornjs/aws`)
 - `packages/azure` — Azure provider (`@airhornjs/azure`)
+- `packages/pingram` — Pingram provider (`@airhornjs/pingram`)
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -73,12 +73,13 @@ Check out the documentation and providers to learn more!
 | [`@airhornjs/twilio`](packages/twilio) | Twilio provider for SMS and Email (SendGrid) | [README](packages/twilio/README.md) |
 | [`@airhornjs/aws`](packages/aws) | AWS provider for SMS (SNS), Email (SES), and Push (SNS) | [README](packages/aws/README.md) |
 | [`@airhornjs/azure`](packages/azure) | Azure provider for SMS, Email, and Push | [README](packages/azure/README.md) |
+| [`@airhornjs/pingram`](packages/pingram) | Pingram provider for SMS, Email, and Push | [README](packages/pingram/README.md) |
 
 # Providers
 
 We currently support multiple providers and you can easily add more by following the `AirhornProvider` interface. Here are the supported providers:
 
-We currently support `twilio`, `aws`, and `azure` with thier offerings. Here is a chart showing what functionality is in each:
+We currently support `twilio`, `aws`, `azure`, and `pingram` with thier offerings. Here is a chart showing what functionality is in each:
 
 | Provider | SMS | Email | Push | Webhook |
 |----------|-----|-------|------|---------|
@@ -86,6 +87,7 @@ We currently support `twilio`, `aws`, and `azure` with thier offerings. Here is 
 | `@airhornjs/twilio`   | ✅  | ✅    | ❌   | ❌      |
 | `@airhornjs/aws`      | ✅  | ✅    | ✅   | ❌      |
 | `@airhornjs/azure`      | ✅  | ✅    | ✅   | ❌      |
+| `@airhornjs/pingram`      | ✅  | ✅    | ✅   | ❌      |
 
 Note: We used to support firebase because of mobile push but it made more sense to focus on `aws` and `azure` because it is more comprehensive.
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "publish:airhorn": "pnpm --filter 'airhorn' run build:publish",
     "publish:aws": "pnpm --filter '@airhornjs/aws' run build:publish",
     "publish:azure": "pnpm --filter '@airhornjs/azure' run build:publish",
+    "publish:pingram": "pnpm --filter '@airhornjs/pingram' run build:publish",
     "publish:twilio": "pnpm --filter '@airhornjs/twilio' run build:publish",
     "build": "pnpm -r build",
     "clean": "pnpm -r clean"

--- a/packages/airhorn/README.md
+++ b/packages/airhorn/README.md
@@ -692,7 +692,7 @@ An example of the `markdown` format is located at `./packages/airhorn/test/fixtu
 
 # Core Supported Providers
 
-We currently support `twilio`, `aws`, and `azure` with thier offerings. Here is a chart showing what functionality is in each:
+We currently support `twilio`, `aws`, `azure`, and `pingram` with thier offerings. Here is a chart showing what functionality is in each:
 
 | Provider | SMS | Email | Push | Webhook |
 |----------|-----|-------|------|---------|
@@ -700,6 +700,7 @@ We currently support `twilio`, `aws`, and `azure` with thier offerings. Here is 
 | `@airhornjs/twilio`   | ✅  | ✅    | ❌   | ❌      |
 | `@airhornjs/aws`      | ✅  | ✅    | ✅   | ❌      |
 | `@airhornjs/azure`      | ✅  | ✅    | ✅   | ❌      |
+| `@airhornjs/pingram`      | ✅  | ✅    | ✅   | ❌      |
 
 Note: We used to support firebase because of mobile push but it made more sense to focus on `aws` and `azure` because it is more comprehensive.
 

--- a/packages/pingram/LICENSE
+++ b/packages/pingram/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Jared Wray
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pingram/README.md
+++ b/packages/pingram/README.md
@@ -1,0 +1,202 @@
+![Airhorn](https://airhorn.org/logo.svg "Airhorn")
+
+---
+
+[![tests](https://github.com/jaredwray/airhorn/actions/workflows/tests.yml/badge.svg)](https://github.com/jaredwray/airhorn/actions/workflows/tests.yml)
+[![codecov](https://codecov.io/gh/jaredwray/airhorn/branch/main/graph/badge.svg?token=4OJEEB67Q5)](https://codecov.io/gh/jaredwray/airhorn)
+[![license](https://img.shields.io/github/license/jaredwray/airhorn)](https://github.com/jaredwray/airhorn/blob/master/LICENSE)
+[![npm](https://img.shields.io/npm/dm/@airhornjs/pingram)](https://npmjs.com/package/@airhornjs/pingram)
+[![npm](https://img.shields.io/npm/v/@airhornjs/pingram)](https://npmjs.com/package/@airhornjs/pingram)
+
+# @airhornjs/pingram
+
+[Pingram](https://www.pingram.io) (formerly NotificationAPI) provider for Airhorn.
+
+## Installation
+
+```bash
+npm install airhorn @airhornjs/pingram
+```
+
+## Features
+
+- SMS sending via the Pingram API
+- Email sending via the Pingram API
+- Mobile push notifications via the Pingram API
+- One API key for all channels — no per-channel infrastructure to configure
+- Multi-region support (`us`, `eu`, `ca`)
+- Automatic error handling and integration with Airhorn's notification system
+
+## Usage
+
+### SMS with Pingram
+
+```typescript
+import { Airhorn, AirhornSendType } from 'airhorn';
+import { AirhornPingram } from '@airhornjs/pingram';
+
+// Create Pingram provider
+const pingramProvider = new AirhornPingram({
+  apiKey: 'pingram_sk_your_api_key',
+});
+
+// Create Airhorn instance with Pingram provider
+const airhorn = new Airhorn({
+  providers: [pingramProvider],
+});
+
+const data = {
+  orderId: '12345',
+  customerName: 'John',
+};
+
+// Send SMS
+const template = {
+  from: '+1234567890', // Optional: your Pingram sender number (defaults to your provisioned number)
+  content: 'Hello <%= customerName %>!, your order #<%= orderId %> has been shipped!',
+};
+
+const result = await airhorn.send(
+  '+16175551212', // to (E.164 format)
+  template,
+  data,
+  AirhornSendType.SMS
+);
+```
+
+### Email with Pingram
+
+```typescript
+import { Airhorn, AirhornSendType } from 'airhorn';
+import { AirhornPingram } from '@airhornjs/pingram';
+
+const pingramProvider = new AirhornPingram({
+  apiKey: 'pingram_sk_your_api_key',
+});
+
+const airhorn = new Airhorn({
+  providers: [pingramProvider],
+});
+
+const data = {
+  orderId: '656565',
+  customerName: 'John',
+};
+
+// Send Email
+const template = {
+  from: 'notifications@yourdomain.com', // Optional: must be a verified sender in Pingram
+  subject: 'Order Confirmation: <%= orderId %>',
+  content: 'Hi <%= customerName %>, your order #<%= orderId %> has been confirmed!',
+};
+
+const result = await airhorn.send(
+  'recipient@example.com', // to
+  template,
+  data,
+  AirhornSendType.Email
+);
+```
+
+### Mobile Push Notifications with Pingram
+
+Pingram delivers mobile push notifications to the device tokens registered for a user, so the `to` value is the Pingram user identifier. Device tokens are registered through the Pingram client SDKs in your mobile apps.
+
+```typescript
+import { Airhorn, AirhornSendType } from 'airhorn';
+import { AirhornPingram } from '@airhornjs/pingram';
+
+const pingramProvider = new AirhornPingram({
+  apiKey: 'pingram_sk_your_api_key',
+});
+
+const airhorn = new Airhorn({
+  providers: [pingramProvider],
+});
+
+const data = {
+  orderId: '12345',
+  customerName: 'John',
+};
+
+const template = {
+  from: 'YourApp',
+  subject: 'New Order', // Used as the push notification title
+  content: 'Hi <%= customerName %>, you have a new order #<%= orderId %>',
+};
+
+await airhorn.send(
+  'user-123', // Pingram user id with registered push tokens
+  template,
+  data,
+  AirhornSendType.MobilePush
+);
+```
+
+### Custom Capabilities
+
+You can specify which services to enable using the `capabilities` option:
+
+```typescript
+// SMS only
+const smsProvider = new AirhornPingram({
+  apiKey: 'pingram_sk_your_api_key',
+  capabilities: [AirhornSendType.SMS],
+});
+
+// Email only
+const emailProvider = new AirhornPingram({
+  apiKey: 'pingram_sk_your_api_key',
+  capabilities: [AirhornSendType.Email],
+});
+
+// All capabilities (explicit)
+const allProvider = new AirhornPingram({
+  apiKey: 'pingram_sk_your_api_key',
+  capabilities: [AirhornSendType.SMS, AirhornSendType.Email, AirhornSendType.MobilePush],
+});
+```
+
+## Configuration
+
+### AirhornPingramOptions
+
+- `apiKey` (required): Your Pingram API key (starts with `pingram_sk_`)
+- `region` (optional): Pingram API region — `us` (default), `eu`, or `ca`
+- `baseUrl` (optional): Custom base URL for the Pingram API (overrides `region`)
+- `notificationType` (optional): The Pingram notification type identifier used for sends (defaults to `airhorn`). Pingram creates the notification type automatically if it does not exist
+- `capabilities` (optional): Array of `AirhornSendType` values to specify which services to enable (defaults to SMS, Email, and MobilePush)
+
+## Additional Options
+
+Any additional send options are merged into the Pingram send request, so you can use Pingram features like merge tag parameters, scheduling, and template overrides:
+
+```typescript
+await airhorn.send(to, template, data, AirhornSendType.Email, {
+  parameters: { firstName: 'John' }, // Pingram template merge tags
+  schedule: '2026-12-25T00:00:00Z',  // Schedule delivery
+  templateId: 'my_template',         // Use a specific Pingram template
+});
+```
+
+## Prerequisites
+
+1. Create a [Pingram](https://www.pingram.io) account
+2. Get your API key from the Pingram dashboard
+3. For SMS: use the included number or provision your own through Pingram
+4. For Email: verify your sending domain (or use Pingram's shared domain)
+5. For Mobile Push: register device tokens for your users via the Pingram client SDKs
+
+## Testing
+
+```bash
+pnpm test
+```
+
+# How to Contribute 
+
+Now that you've set up your workspace, you're ready to contribute changes to the `airhorn` repository you can refer to the [CONTRIBUTING](CONTRIBUTING.md) guide. If you have any questions please feel free to ask by creating an issue and label it `question`.
+
+# Licensing and Copyright
+
+This project is [MIT License © Jared Wray](LICENSE)

--- a/packages/pingram/README.md
+++ b/packages/pingram/README.md
@@ -166,16 +166,29 @@ const allProvider = new AirhornPingram({
 - `baseUrl` (optional): Custom base URL for the Pingram API (overrides `region`)
 - `notificationType` (optional): The Pingram notification type identifier used for sends (defaults to `airhorn`). Pingram creates the notification type automatically if it does not exist
 - `capabilities` (optional): Array of `AirhornSendType` values to specify which services to enable (defaults to SMS, Email, and MobilePush)
+- `sendDefaults` (optional): Typed Pingram request defaults merged into every send request (e.g. `templateId`, `parameters`, or channel content defaults like `email.senderName` and `sms.from`). Message-derived values take precedence
 
-## Additional Options
+## Send Defaults
 
-Any additional send options are merged into the Pingram send request, so you can use Pingram features like merge tag parameters, scheduling, and template overrides:
+Pingram-specific request fields are configured on the provider through `sendDefaults`, keeping the `airhorn.send()` surface generic. The defaults are fully typed against the Pingram SDK and merged into every send request beneath the message values, so the message always wins:
 
 ```typescript
-await airhorn.send(to, template, data, AirhornSendType.Email, {
-  parameters: { firstName: 'John' }, // Pingram template merge tags
-  schedule: '2026-12-25T00:00:00Z',  // Schedule delivery
-  templateId: 'my_template',         // Use a specific Pingram template
+const pingramProvider = new AirhornPingram({
+  apiKey: 'pingram_sk_your_api_key',
+  sendDefaults: {
+    templateId: 'my_template',          // Use a specific Pingram template
+    parameters: { plan: 'pro' },        // Pingram template merge tags
+    sms: { from: '+15550001111' },      // Default SMS sender number
+    email: { senderName: 'Acme Corp' }, // Default email sender name
+  },
+});
+```
+
+For one-off, per-message Pingram options (for example a scheduled delivery), call the provider directly — the second argument is merged into the request last and can override anything:
+
+```typescript
+await pingramProvider.send(message, {
+  schedule: '2026-12-25T00:00:00Z',
 });
 ```
 

--- a/packages/pingram/package.json
+++ b/packages/pingram/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@airhornjs/pingram",
+  "version": "7.0.0",
+  "description": "Pingram provider for Airhorn",
+  "license": "MIT",
+  "author": "Jared Wray <me@jaredwray.com>",
+  "homepage": "https://github.com/jaredwray/airhorn/tree/main/packages/pingram#readme",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "lint": "biome check --write --error-on-warnings",
+    "test": "pnpm lint && vitest run --coverage",
+    "test:ci": "biome check --error-on-warnings && vitest run --coverage",
+    "clean": "rimraf ./dist ./coverage ./node_modules ./package-lock.json ./pnpm-lock.yaml",
+    "prepublishOnly": "pnpm build",
+    "build:publish": "pnpm publish --access public --no-git-checks --provenance",
+    "build": "tsdown"
+  },
+  "dependencies": {
+    "pingram": "^1.0.14"
+  },
+  "peerDependencies": {
+    "airhorn": "workspace:*"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jaredwray/airhorn.git",
+    "directory": "packages/pingram"
+  },
+  "keywords": [
+    "airhorn",
+    "notifications",
+    "pingram",
+    "notificationapi",
+    "sms",
+    "email",
+    "push",
+    "mobile"
+  ],
+  "files": [
+    "dist",
+    "LICENSE"
+  ]
+}

--- a/packages/pingram/src/index.ts
+++ b/packages/pingram/src/index.ts
@@ -9,7 +9,27 @@ import {
 	Pingram,
 	type PingramRegion,
 	type SenderPostBody,
+	type SenderPostBodyEmail,
+	type SenderPostBodyMobilePush,
+	type SenderPostBodySms,
 } from "pingram";
+
+/**
+ * Typed Pingram request defaults merged into every send request. Top-level
+ * fields (e.g. `templateId`, `schedule`, `parameters`) are applied beneath
+ * the provider-managed fields, and the channel content objects (`email`,
+ * `sms`, `mobile_push`) and `to` are merged beneath the message-derived
+ * values, so the message always wins. The notification `type` comes from
+ * `notificationType` and the channels from the Airhorn message type.
+ */
+export type AirhornPingramSendDefaults = Omit<
+	Partial<SenderPostBody>,
+	"type" | "forceChannels" | "email" | "sms" | "mobile_push"
+> & {
+	email?: Partial<SenderPostBodyEmail>;
+	sms?: Partial<SenderPostBodySms>;
+	mobile_push?: Partial<SenderPostBodyMobilePush>;
+};
 
 export type AirhornPingramOptions = {
 	/**
@@ -34,6 +54,13 @@ export type AirhornPingramOptions = {
 	 * The capabilities to enable (defaults to SMS, Email, and MobilePush).
 	 */
 	capabilities?: AirhornSendType[];
+	/**
+	 * Pingram request defaults merged into every send request, e.g.
+	 * `templateId`, `parameters`, or channel content defaults such as
+	 * `email.senderName` and `sms.from`. Message-derived values take
+	 * precedence over these defaults.
+	 */
+	sendDefaults?: AirhornPingramSendDefaults;
 };
 
 export class AirhornPingram implements AirhornProvider {
@@ -42,6 +69,14 @@ export class AirhornPingram implements AirhornProvider {
 
 	private client: Pingram;
 	private notificationType: string;
+	private baseDefaults: Omit<
+		AirhornPingramSendDefaults,
+		"to" | "email" | "sms" | "mobile_push"
+	>;
+	private channelDefaults: Pick<
+		AirhornPingramSendDefaults,
+		"to" | "email" | "sms" | "mobile_push"
+	>;
 
 	constructor(options: AirhornPingramOptions) {
 		if (!options.apiKey) {
@@ -56,6 +91,18 @@ export class AirhornPingram implements AirhornProvider {
 		];
 
 		this.notificationType = options.notificationType || "airhorn";
+
+		// Split the send defaults so each send only carries the top-level
+		// defaults plus the content defaults for its own channel
+		const {
+			to,
+			email,
+			sms,
+			mobile_push: mobilePush,
+			...baseDefaults
+		} = options.sendDefaults ?? {};
+		this.baseDefaults = baseDefaults;
+		this.channelDefaults = { to, email, sms, mobile_push: mobilePush };
 
 		this.client = new Pingram({
 			apiKey: options.apiKey,
@@ -114,16 +161,20 @@ export class AirhornPingram implements AirhornProvider {
 		// biome-ignore lint/suspicious/noExplicitAny: expected
 		options?: any,
 	): Promise<AirhornProviderSendResult> {
+		const smsDefaults = this.channelDefaults.sms;
 		const body: SenderPostBody = {
+			...this.baseDefaults,
 			type: this.notificationType,
 			to: {
+				...this.channelDefaults.to,
 				id: message.to,
 				number: message.to,
 			},
 			forceChannels: [ChannelsEnum.SMS],
 			sms: {
+				...smsDefaults,
 				message: message.content,
-				from: message.from || undefined,
+				from: message.from || smsDefaults?.from,
 			},
 			...options,
 		};
@@ -136,17 +187,21 @@ export class AirhornPingram implements AirhornProvider {
 		// biome-ignore lint/suspicious/noExplicitAny: expected
 		options?: any,
 	): Promise<AirhornProviderSendResult> {
+		const emailDefaults = this.channelDefaults.email;
 		const body: SenderPostBody = {
+			...this.baseDefaults,
 			type: this.notificationType,
 			to: {
+				...this.channelDefaults.to,
 				id: message.to,
 				email: message.to,
 			},
 			forceChannels: [ChannelsEnum.EMAIL],
 			email: {
-				subject: message.subject || "Notification",
+				...emailDefaults,
+				subject: message.subject || emailDefaults?.subject || "Notification",
 				html: message.content,
-				senderEmail: message.from || undefined,
+				senderEmail: message.from || emailDefaults?.senderEmail,
 			},
 			...options,
 		};
@@ -161,14 +216,18 @@ export class AirhornPingram implements AirhornProvider {
 	): Promise<AirhornProviderSendResult> {
 		// Pingram delivers mobile push to the device tokens registered for the
 		// user, so `to` is the Pingram user identifier
+		const pushDefaults = this.channelDefaults.mobile_push;
 		const body: SenderPostBody = {
+			...this.baseDefaults,
 			type: this.notificationType,
 			to: {
+				...this.channelDefaults.to,
 				id: message.to,
 			},
 			forceChannels: [ChannelsEnum.PUSH],
 			mobile_push: {
-				title: message.subject || "Notification",
+				...pushDefaults,
+				title: message.subject || pushDefaults?.title || "Notification",
 				message: message.content,
 			},
 			...options,

--- a/packages/pingram/src/index.ts
+++ b/packages/pingram/src/index.ts
@@ -1,0 +1,208 @@
+import {
+	type AirhornProvider,
+	type AirhornProviderMessage,
+	type AirhornProviderSendResult,
+	AirhornSendType,
+} from "airhorn";
+import {
+	ChannelsEnum,
+	Pingram,
+	type PingramRegion,
+	type SenderPostBody,
+} from "pingram";
+
+export type AirhornPingramOptions = {
+	/**
+	 * Pingram API key (starts with `pingram_sk_`). Required.
+	 */
+	apiKey: string;
+	/**
+	 * Pingram API region: "us" (default), "eu", or "ca".
+	 */
+	region?: PingramRegion;
+	/**
+	 * Custom base URL for the Pingram API (overrides region).
+	 */
+	baseUrl?: string;
+	/**
+	 * The Pingram notification type identifier used for sends. Pingram creates
+	 * the notification type automatically if it does not exist.
+	 * @default "airhorn"
+	 */
+	notificationType?: string;
+	/**
+	 * The capabilities to enable (defaults to SMS, Email, and MobilePush).
+	 */
+	capabilities?: AirhornSendType[];
+};
+
+export class AirhornPingram implements AirhornProvider {
+	public name = "pingram";
+	public capabilities: AirhornSendType[];
+
+	private client: Pingram;
+	private notificationType: string;
+
+	constructor(options: AirhornPingramOptions) {
+		if (!options.apiKey) {
+			throw new Error("AirhornPingram requires an apiKey");
+		}
+
+		// Set capabilities from options or default to SMS, Email, and MobilePush
+		this.capabilities = options.capabilities || [
+			AirhornSendType.SMS,
+			AirhornSendType.Email,
+			AirhornSendType.MobilePush,
+		];
+
+		this.notificationType = options.notificationType || "airhorn";
+
+		this.client = new Pingram({
+			apiKey: options.apiKey,
+			region: options.region,
+			baseUrl: options.baseUrl,
+		});
+	}
+
+	async send(
+		message: AirhornProviderMessage,
+		// biome-ignore lint/suspicious/noExplicitAny: expected
+		options?: any,
+	): Promise<AirhornProviderSendResult> {
+		const result: AirhornProviderSendResult = {
+			success: false,
+			response: null,
+			errors: [],
+		};
+
+		try {
+			if (!this.capabilities.includes(message.type)) {
+				throw new Error(
+					`AirhornPingram is not configured for message type: ${message.type}`,
+				);
+			}
+
+			if (message.type === AirhornSendType.SMS) {
+				return await this.sendSMS(message, options);
+			}
+
+			if (message.type === AirhornSendType.Email) {
+				return await this.sendEmail(message, options);
+			}
+
+			if (message.type === AirhornSendType.MobilePush) {
+				return await this.sendMobilePush(message, options);
+			}
+
+			throw new Error(
+				`AirhornPingram does not support message type: ${message.type}`,
+			);
+		} catch (error) {
+			const err = error instanceof Error ? error : new Error(String(error));
+			result.errors.push(err);
+			result.response = {
+				error: err.message,
+				details: error,
+			};
+		}
+
+		return result;
+	}
+
+	private async sendSMS(
+		message: AirhornProviderMessage,
+		// biome-ignore lint/suspicious/noExplicitAny: expected
+		options?: any,
+	): Promise<AirhornProviderSendResult> {
+		const body: SenderPostBody = {
+			type: this.notificationType,
+			to: {
+				id: message.to,
+				number: message.to,
+			},
+			forceChannels: [ChannelsEnum.SMS],
+			sms: {
+				message: message.content,
+				from: message.from || undefined,
+			},
+			...options,
+		};
+
+		return this.executeSend(body);
+	}
+
+	private async sendEmail(
+		message: AirhornProviderMessage,
+		// biome-ignore lint/suspicious/noExplicitAny: expected
+		options?: any,
+	): Promise<AirhornProviderSendResult> {
+		const body: SenderPostBody = {
+			type: this.notificationType,
+			to: {
+				id: message.to,
+				email: message.to,
+			},
+			forceChannels: [ChannelsEnum.EMAIL],
+			email: {
+				subject: message.subject || "Notification",
+				html: message.content,
+				senderEmail: message.from || undefined,
+			},
+			...options,
+		};
+
+		return this.executeSend(body);
+	}
+
+	private async sendMobilePush(
+		message: AirhornProviderMessage,
+		// biome-ignore lint/suspicious/noExplicitAny: expected
+		options?: any,
+	): Promise<AirhornProviderSendResult> {
+		// Pingram delivers mobile push to the device tokens registered for the
+		// user, so `to` is the Pingram user identifier
+		const body: SenderPostBody = {
+			type: this.notificationType,
+			to: {
+				id: message.to,
+			},
+			forceChannels: [ChannelsEnum.PUSH],
+			mobile_push: {
+				title: message.subject || "Notification",
+				message: message.content,
+			},
+			...options,
+		};
+
+		return this.executeSend(body);
+	}
+
+	private async executeSend(
+		body: SenderPostBody,
+	): Promise<AirhornProviderSendResult> {
+		const result: AirhornProviderSendResult = {
+			success: false,
+			response: null,
+			errors: [],
+		};
+
+		try {
+			const response = await this.client.send(body);
+
+			result.success = true;
+			result.response = {
+				trackingId: response.trackingId,
+				messages: response.messages,
+			};
+		} catch (error) {
+			const err = error instanceof Error ? error : new Error(String(error));
+			result.errors.push(err);
+			result.response = {
+				error: err.message,
+				details: error,
+			};
+		}
+
+		return result;
+	}
+}

--- a/packages/pingram/test/index.test.ts
+++ b/packages/pingram/test/index.test.ts
@@ -1,0 +1,477 @@
+import { AirhornSendType } from "airhorn";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AirhornPingram } from "../src/index";
+import { mockPingramClient, mockPingramSend } from "./setup";
+
+describe("AirhornPingram", () => {
+	let provider: AirhornPingram;
+	const mockOptions = {
+		apiKey: "pingram_sk_test_key",
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		provider = new AirhornPingram(mockOptions);
+	});
+
+	describe("constructor", () => {
+		it("should create instance with SMS, Email, and MobilePush capabilities by default", () => {
+			expect(provider).toBeDefined();
+			expect(provider.name).toBe("pingram");
+			expect(provider.capabilities).toContain(AirhornSendType.SMS);
+			expect(provider.capabilities).toContain(AirhornSendType.Email);
+			expect(provider.capabilities).toContain(AirhornSendType.MobilePush);
+		});
+
+		it("should throw an error when apiKey is missing", () => {
+			expect(() => new AirhornPingram({ apiKey: "" })).toThrow(
+				"AirhornPingram requires an apiKey",
+			);
+		});
+
+		it("should accept custom capabilities", () => {
+			const smsOnlyProvider = new AirhornPingram({
+				...mockOptions,
+				capabilities: [AirhornSendType.SMS],
+			});
+			expect(smsOnlyProvider.capabilities).toEqual([AirhornSendType.SMS]);
+			expect(smsOnlyProvider.capabilities).not.toContain(AirhornSendType.Email);
+
+			const emailOnlyProvider = new AirhornPingram({
+				...mockOptions,
+				capabilities: [AirhornSendType.Email],
+			});
+			expect(emailOnlyProvider.capabilities).toEqual([AirhornSendType.Email]);
+			expect(emailOnlyProvider.capabilities).not.toContain(AirhornSendType.SMS);
+		});
+
+		it("should pass the api key, region, and base url to the Pingram client", () => {
+			new AirhornPingram({
+				apiKey: "pingram_sk_eu_key",
+				region: "eu",
+				baseUrl: "https://custom.api.example.com",
+			});
+
+			expect(mockPingramClient).toHaveBeenCalledWith({
+				apiKey: "pingram_sk_eu_key",
+				region: "eu",
+				baseUrl: "https://custom.api.example.com",
+			});
+		});
+	});
+
+	describe("SMS sending", () => {
+		const mockMessage = {
+			to: "+16175551212",
+			from: "+1234567890",
+			content: "Test SMS message",
+			type: AirhornSendType.SMS,
+		};
+
+		it("should send SMS successfully", async () => {
+			mockPingramSend.mockResolvedValueOnce({
+				trackingId: "tracking-123",
+				messages: ["queued"],
+			});
+
+			const result = await provider.send(mockMessage);
+
+			expect(result.success).toBe(true);
+			expect(result.response).toEqual({
+				trackingId: "tracking-123",
+				messages: ["queued"],
+			});
+			expect(result.errors).toHaveLength(0);
+			expect(mockPingramSend).toHaveBeenCalledWith({
+				type: "airhorn",
+				to: {
+					id: "+16175551212",
+					number: "+16175551212",
+				},
+				forceChannels: ["SMS"],
+				sms: {
+					message: "Test SMS message",
+					from: "+1234567890",
+				},
+			});
+		});
+
+		it("should send SMS without a from number", async () => {
+			mockPingramSend.mockResolvedValueOnce({
+				trackingId: "tracking-124",
+				messages: [],
+			});
+
+			const result = await provider.send({ ...mockMessage, from: "" });
+
+			expect(result.success).toBe(true);
+			expect(mockPingramSend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					sms: {
+						message: "Test SMS message",
+						from: undefined,
+					},
+				}),
+			);
+		});
+
+		it("should use a custom notification type", async () => {
+			const customProvider = new AirhornPingram({
+				...mockOptions,
+				notificationType: "order_updates",
+			});
+			mockPingramSend.mockResolvedValueOnce({
+				trackingId: "tracking-125",
+				messages: [],
+			});
+
+			await customProvider.send(mockMessage);
+
+			expect(mockPingramSend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "order_updates",
+				}),
+			);
+		});
+
+		it("should merge additional send options into the request", async () => {
+			mockPingramSend.mockResolvedValueOnce({
+				trackingId: "tracking-126",
+				messages: [],
+			});
+
+			await provider.send(mockMessage, {
+				parameters: { firstName: "John" },
+				schedule: "2026-12-25T00:00:00Z",
+			});
+
+			expect(mockPingramSend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					parameters: { firstName: "John" },
+					schedule: "2026-12-25T00:00:00Z",
+				}),
+			);
+		});
+
+		it("should let send options override the provider-built fields", async () => {
+			mockPingramSend.mockResolvedValueOnce({
+				trackingId: "tracking-127",
+				messages: [],
+			});
+
+			await provider.send(mockMessage, {
+				forceChannels: ["SMS", "CALL"],
+				to: { id: "user-42", number: "+15550001111" },
+			});
+
+			expect(mockPingramSend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					forceChannels: ["SMS", "CALL"],
+					to: { id: "user-42", number: "+15550001111" },
+				}),
+			);
+		});
+
+		it("should handle SMS send errors", async () => {
+			const errorMessage = "Invalid phone number";
+			mockPingramSend.mockRejectedValueOnce(new Error(errorMessage));
+
+			const result = await provider.send(mockMessage);
+
+			expect(result.success).toBe(false);
+			expect(result.errors).toHaveLength(1);
+			expect(result.errors[0].message).toBe(errorMessage);
+			expect(result.response).toHaveProperty("error", errorMessage);
+		});
+
+		it("should handle non-Error rejections", async () => {
+			mockPingramSend.mockRejectedValueOnce("string failure");
+
+			const result = await provider.send(mockMessage);
+
+			expect(result.success).toBe(false);
+			expect(result.errors).toHaveLength(1);
+			expect(result.errors[0].message).toBe("string failure");
+		});
+	});
+
+	describe("Email sending", () => {
+		const mockEmailMessage = {
+			to: "recipient@example.com",
+			from: "sender@example.com",
+			subject: "Test Subject",
+			content: "<p>Test email content</p>",
+			type: AirhornSendType.Email,
+		};
+
+		it("should send email successfully", async () => {
+			mockPingramSend.mockResolvedValueOnce({
+				trackingId: "tracking-200",
+				messages: ["queued"],
+			});
+
+			const result = await provider.send(mockEmailMessage);
+
+			expect(result.success).toBe(true);
+			expect(result.response).toEqual({
+				trackingId: "tracking-200",
+				messages: ["queued"],
+			});
+			expect(result.errors).toHaveLength(0);
+			expect(mockPingramSend).toHaveBeenCalledWith({
+				type: "airhorn",
+				to: {
+					id: "recipient@example.com",
+					email: "recipient@example.com",
+				},
+				forceChannels: ["EMAIL"],
+				email: {
+					subject: "Test Subject",
+					html: "<p>Test email content</p>",
+					senderEmail: "sender@example.com",
+				},
+			});
+		});
+
+		it("should default the subject when not provided", async () => {
+			mockPingramSend.mockResolvedValueOnce({
+				trackingId: "tracking-201",
+				messages: [],
+			});
+
+			const result = await provider.send({
+				...mockEmailMessage,
+				subject: undefined,
+			});
+
+			expect(result.success).toBe(true);
+			expect(mockPingramSend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					email: expect.objectContaining({
+						subject: "Notification",
+					}),
+				}),
+			);
+		});
+
+		it("should send email without a sender email", async () => {
+			mockPingramSend.mockResolvedValueOnce({
+				trackingId: "tracking-202",
+				messages: [],
+			});
+
+			const result = await provider.send({ ...mockEmailMessage, from: "" });
+
+			expect(result.success).toBe(true);
+			expect(mockPingramSend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					email: expect.objectContaining({
+						senderEmail: undefined,
+					}),
+				}),
+			);
+		});
+
+		it("should merge send options and use a custom notification type", async () => {
+			const customProvider = new AirhornPingram({
+				...mockOptions,
+				notificationType: "order_updates",
+			});
+			mockPingramSend.mockResolvedValueOnce({
+				trackingId: "tracking-203",
+				messages: [],
+			});
+
+			await customProvider.send(mockEmailMessage, {
+				parameters: { firstName: "John" },
+			});
+
+			expect(mockPingramSend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "order_updates",
+					parameters: { firstName: "John" },
+				}),
+			);
+		});
+
+		it("should handle email send errors", async () => {
+			const errorMessage = "Sender domain not verified";
+			mockPingramSend.mockRejectedValueOnce(new Error(errorMessage));
+
+			const result = await provider.send(mockEmailMessage);
+
+			expect(result.success).toBe(false);
+			expect(result.errors).toHaveLength(1);
+			expect(result.errors[0].message).toBe(errorMessage);
+		});
+	});
+
+	describe("Mobile push sending", () => {
+		const mockPushMessage = {
+			to: "user-123",
+			from: "YourApp",
+			subject: "New Order",
+			content: "You have a new order #12345",
+			type: AirhornSendType.MobilePush,
+		};
+
+		it("should send mobile push successfully", async () => {
+			mockPingramSend.mockResolvedValueOnce({
+				trackingId: "tracking-300",
+				messages: ["queued"],
+			});
+
+			const result = await provider.send(mockPushMessage);
+
+			expect(result.success).toBe(true);
+			expect(result.response).toEqual({
+				trackingId: "tracking-300",
+				messages: ["queued"],
+			});
+			expect(result.errors).toHaveLength(0);
+			expect(mockPingramSend).toHaveBeenCalledWith({
+				type: "airhorn",
+				to: {
+					id: "user-123",
+				},
+				forceChannels: ["PUSH"],
+				mobile_push: {
+					title: "New Order",
+					message: "You have a new order #12345",
+				},
+			});
+		});
+
+		it("should default the title when subject is not provided", async () => {
+			mockPingramSend.mockResolvedValueOnce({
+				trackingId: "tracking-301",
+				messages: [],
+			});
+
+			const result = await provider.send({
+				...mockPushMessage,
+				subject: undefined,
+			});
+
+			expect(result.success).toBe(true);
+			expect(mockPingramSend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					mobile_push: expect.objectContaining({
+						title: "Notification",
+					}),
+				}),
+			);
+		});
+
+		it("should merge send options and use a custom notification type", async () => {
+			const customProvider = new AirhornPingram({
+				...mockOptions,
+				notificationType: "order_updates",
+			});
+			mockPingramSend.mockResolvedValueOnce({
+				trackingId: "tracking-302",
+				messages: [],
+			});
+
+			await customProvider.send(mockPushMessage, {
+				parameters: { firstName: "John" },
+			});
+
+			expect(mockPingramSend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "order_updates",
+					parameters: { firstName: "John" },
+				}),
+			);
+		});
+
+		it("should handle mobile push send errors", async () => {
+			const errorMessage = "No push tokens registered for user";
+			mockPingramSend.mockRejectedValueOnce(new Error(errorMessage));
+
+			const result = await provider.send(mockPushMessage);
+
+			expect(result.success).toBe(false);
+			expect(result.errors).toHaveLength(1);
+			expect(result.errors[0].message).toBe(errorMessage);
+		});
+	});
+
+	describe("send dispatch", () => {
+		it("should return an error for unsupported message types", async () => {
+			const result = await provider.send({
+				to: "https://example.com/webhook",
+				from: "airhorn",
+				content: "{}",
+				type: AirhornSendType.Webhook,
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.errors).toHaveLength(1);
+			expect(result.errors[0].message).toContain(
+				"AirhornPingram is not configured for message type: webhook",
+			);
+			expect(mockPingramSend).not.toHaveBeenCalled();
+		});
+
+		it("should return an error when the message type is not in capabilities", async () => {
+			const smsOnlyProvider = new AirhornPingram({
+				...mockOptions,
+				capabilities: [AirhornSendType.SMS],
+			});
+
+			const result = await smsOnlyProvider.send({
+				to: "recipient@example.com",
+				from: "sender@example.com",
+				content: "Test",
+				type: AirhornSendType.Email,
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.errors).toHaveLength(1);
+			expect(result.errors[0].message).toContain(
+				"AirhornPingram is not configured for message type: email",
+			);
+			expect(mockPingramSend).not.toHaveBeenCalled();
+		});
+
+		it("should handle non-Error values thrown during dispatch", async () => {
+			vi.spyOn(
+				provider as unknown as { sendSMS: () => Promise<never> },
+				"sendSMS",
+			).mockRejectedValueOnce("dispatch failure");
+
+			const result = await provider.send({
+				to: "+16175551212",
+				from: "+1234567890",
+				content: "Test",
+				type: AirhornSendType.SMS,
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.errors).toHaveLength(1);
+			expect(result.errors[0].message).toBe("dispatch failure");
+		});
+
+		it("should return an error for capability values it cannot dispatch", async () => {
+			const webhookProvider = new AirhornPingram({
+				...mockOptions,
+				capabilities: [AirhornSendType.Webhook],
+			});
+
+			const result = await webhookProvider.send({
+				to: "https://example.com/webhook",
+				from: "airhorn",
+				content: "{}",
+				type: AirhornSendType.Webhook,
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.errors).toHaveLength(1);
+			expect(result.errors[0].message).toContain(
+				"AirhornPingram does not support message type: webhook",
+			);
+			expect(mockPingramSend).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/pingram/test/index.test.ts
+++ b/packages/pingram/test/index.test.ts
@@ -397,6 +397,184 @@ describe("AirhornPingram", () => {
 		});
 	});
 
+	describe("send defaults", () => {
+		const sendDefaults = {
+			templateId: "my_template",
+			parameters: { firstName: "John" },
+			to: { timezone: "America/New_York" },
+			sms: { from: "+15550009999", mediaUrls: ["https://example.com/a.png"] },
+			email: {
+				subject: "Default Subject",
+				senderEmail: "default@example.com",
+				senderName: "Acme",
+			},
+			mobile_push: { title: "Default Title" },
+		};
+
+		let defaultsProvider: AirhornPingram;
+
+		beforeEach(() => {
+			defaultsProvider = new AirhornPingram({
+				...mockOptions,
+				sendDefaults,
+			});
+		});
+
+		it("should apply defaults to SMS sends beneath the message values", async () => {
+			mockPingramSend.mockResolvedValueOnce({
+				trackingId: "tracking-400",
+				messages: [],
+			});
+
+			await defaultsProvider.send({
+				to: "+16175551212",
+				from: "",
+				content: "Hello",
+				type: AirhornSendType.SMS,
+			});
+
+			expect(mockPingramSend).toHaveBeenCalledWith({
+				templateId: "my_template",
+				parameters: { firstName: "John" },
+				type: "airhorn",
+				to: {
+					timezone: "America/New_York",
+					id: "+16175551212",
+					number: "+16175551212",
+				},
+				forceChannels: ["SMS"],
+				sms: {
+					from: "+15550009999",
+					mediaUrls: ["https://example.com/a.png"],
+					message: "Hello",
+				},
+			});
+		});
+
+		it("should let the message from win over the SMS default", async () => {
+			mockPingramSend.mockResolvedValueOnce({
+				trackingId: "tracking-401",
+				messages: [],
+			});
+
+			await defaultsProvider.send({
+				to: "+16175551212",
+				from: "+1234567890",
+				content: "Hello",
+				type: AirhornSendType.SMS,
+			});
+
+			expect(mockPingramSend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					sms: expect.objectContaining({
+						from: "+1234567890",
+						message: "Hello",
+					}),
+				}),
+			);
+		});
+
+		it("should apply defaults to email sends beneath the message values", async () => {
+			mockPingramSend.mockResolvedValueOnce({
+				trackingId: "tracking-402",
+				messages: [],
+			});
+
+			await defaultsProvider.send({
+				to: "recipient@example.com",
+				from: "",
+				content: "<p>Hi</p>",
+				type: AirhornSendType.Email,
+			});
+
+			expect(mockPingramSend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					templateId: "my_template",
+					email: {
+						subject: "Default Subject",
+						senderName: "Acme",
+						senderEmail: "default@example.com",
+						html: "<p>Hi</p>",
+					},
+				}),
+			);
+		});
+
+		it("should let the message subject and sender win over email defaults", async () => {
+			mockPingramSend.mockResolvedValueOnce({
+				trackingId: "tracking-403",
+				messages: [],
+			});
+
+			await defaultsProvider.send({
+				to: "recipient@example.com",
+				from: "sender@example.com",
+				subject: "Real Subject",
+				content: "<p>Hi</p>",
+				type: AirhornSendType.Email,
+			});
+
+			expect(mockPingramSend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					email: expect.objectContaining({
+						subject: "Real Subject",
+						senderEmail: "sender@example.com",
+					}),
+				}),
+			);
+		});
+
+		it("should apply defaults to mobile push sends beneath the message values", async () => {
+			mockPingramSend.mockResolvedValueOnce({
+				trackingId: "tracking-404",
+				messages: [],
+			});
+
+			await defaultsProvider.send({
+				to: "user-123",
+				from: "YourApp",
+				content: "You have a new order",
+				type: AirhornSendType.MobilePush,
+			});
+
+			expect(mockPingramSend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					to: {
+						timezone: "America/New_York",
+						id: "user-123",
+					},
+					mobile_push: {
+						title: "Default Title",
+						message: "You have a new order",
+					},
+				}),
+			);
+		});
+
+		it("should let per-call send options override the defaults", async () => {
+			mockPingramSend.mockResolvedValueOnce({
+				trackingId: "tracking-405",
+				messages: [],
+			});
+
+			await defaultsProvider.send(
+				{
+					to: "+16175551212",
+					from: "+1234567890",
+					content: "Hello",
+					type: AirhornSendType.SMS,
+				},
+				{ templateId: "override_template" },
+			);
+
+			expect(mockPingramSend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					templateId: "override_template",
+				}),
+			);
+		});
+	});
+
 	describe("send dispatch", () => {
 		it("should return an error for unsupported message types", async () => {
 			const result = await provider.send({

--- a/packages/pingram/test/setup.ts
+++ b/packages/pingram/test/setup.ts
@@ -1,0 +1,22 @@
+import { vi } from "vitest";
+
+// Mock Pingram Client
+export const mockPingramSend = vi.fn();
+export const mockPingramClient = vi.fn(function Pingram() {
+	return {
+		send: mockPingramSend,
+	};
+});
+
+vi.mock("pingram", () => ({
+	Pingram: mockPingramClient,
+	ChannelsEnum: {
+		EMAIL: "EMAIL",
+		INAPP_WEB: "INAPP_WEB",
+		SMS: "SMS",
+		CALL: "CALL",
+		PUSH: "PUSH",
+		WEB_PUSH: "WEB_PUSH",
+		SLACK: "SLACK",
+	},
+}));

--- a/packages/pingram/tsconfig.json
+++ b/packages/pingram/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"lib": ["ES2022"],
+		"moduleResolution": "node",
+		"esModuleInterop": true,
+		"allowSyntheticDefaultImports": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"types": ["node"],
+		"ignoreDeprecations": "6.0"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/pingram/tsdown.config.ts
+++ b/packages/pingram/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	entry: ["src/index.ts"],
+	format: "esm",
+	dts: true,
+	clean: true,
+	fixedExtension: false,
+});

--- a/packages/pingram/vitest.config.ts
+++ b/packages/pingram/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: "node",
+		setupFiles: ["./test/setup.ts"],
+		coverage: {
+			reporter: ["text", "json", "lcov"],
+			exclude: ["**/node_modules/**", "**/dist/**", "**/test/**", "vitest.config.ts"],
+		},
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,15 @@ importers:
         specifier: workspace:*
         version: link:../airhorn
 
+  packages/pingram:
+    dependencies:
+      airhorn:
+        specifier: workspace:*
+        version: link:../airhorn
+      pingram:
+        specifier: ^1.0.14
+        version: 1.0.14
+
   packages/twilio:
     dependencies:
       '@sendgrid/mail':
@@ -2248,6 +2257,15 @@ packages:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   nunjucks@3.2.4:
     resolution: {integrity: sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==}
     engines: {node: '>= 6.9.0'}
@@ -2316,6 +2334,9 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pingram@1.0.14:
+    resolution: {integrity: sha512-CGFB08ihCmamGx13uuujKMJXGVnSFJkgBy+UAs6grFYQvvoJo+cNnT8KlW+kKAcLsHHVus0WP9j8lyJgpAqSbg==}
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
@@ -2644,6 +2665,9 @@ packages:
   token-stream@1.0.0:
     resolution: {integrity: sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
@@ -2862,6 +2886,12 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   when-exit@2.1.5:
     resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
@@ -5457,6 +5487,10 @@ snapshots:
       emojilib: 2.4.0
       skin-tone: 2.0.0
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   nunjucks@3.2.4:
     dependencies:
       a-sync-waterfall: 1.0.1
@@ -5514,6 +5548,12 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  pingram@1.0.14:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   postcss@8.5.8:
     dependencies:
@@ -5965,6 +6005,8 @@ snapshots:
 
   token-stream@1.0.0: {}
 
+  tr46@0.0.3: {}
+
   tree-kill@1.2.2: {}
 
   trim-lines@3.0.1: {}
@@ -6161,6 +6203,13 @@ snapshots:
   void-elements@3.1.0: {}
 
   web-namespaces@2.0.1: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   when-exit@2.1.5: {}
 

--- a/site/docula.config.ts
+++ b/site/docula.config.ts
@@ -58,7 +58,7 @@ export const onPrepare = async (
 	});
 
 	// Sub-packages
-	for (const name of ["aws", "azure", "twilio"] as const) {
+	for (const name of ["aws", "azure", "pingram", "twilio"] as const) {
 		await writeDocFromReadme({
 			source: path.join(process.cwd(), `packages/${name}/README.md`),
 			dest: path.join(config.sitePath, `docs/${name}.md`),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — a new provider package: `@airhornjs/pingram` (`packages/pingram`), integrating [Pingram](https://www.pingram.io/docs/) (formerly NotificationAPI) as an Airhorn provider.

## What's included

- **`AirhornPingram` provider** wrapping the official [`pingram`](https://www.npmjs.com/package/pingram) Node SDK, implementing `AirhornProvider` with SMS, Email, and Mobile Push capabilities:
  - **SMS** → `to.number` in E.164 format, `sms.message`, optional `sms.from`
  - **Email** → `email.subject`/`email.html`, optional `senderEmail` from the template's `from`
  - **Mobile Push** → `mobile_push.title`/`mobile_push.message`, delivered to device tokens registered for the Pingram user id passed as `to`
  - Each send pins the channel with `forceChannels`
  - **Typed `sendDefaults`** on the provider carry Pingram-specific request fields (`templateId`, `parameters`, `schedule`, channel content defaults like `email.senderName`/`sms.from`) — fully typed against the SDK's `SenderPostBody` (with partial channel objects; provider-managed `type`/`forceChannels` excluded), merged into every request beneath the message-derived values so the message always wins. This keeps the `airhorn.send()` surface generic; one-off per-message options go through direct `provider.send()`, which merges last and can override anything
  - Options: `apiKey` (required), `region` (`us`/`eu`/`ca`), `baseUrl`, `notificationType` (defaults to `airhorn`), `capabilities`, and `sendDefaults` — mirroring the Azure provider's configuration pattern
- **Tests**: 30 vitest tests with the SDK fully mocked, 100% statement/branch/function/line coverage; request bodies, error paths (including non-`Error` rejections), capability gating, `sendDefaults` merge precedence (defaults vs message values vs per-call options), and custom notification types are all asserted on every channel. The mocked `ChannelsEnum` values were verified against the real SDK, and the built ESM output was runtime-checked against the real SDK's serialization (stub `fetch` confirms `POST /send` with the exact body shape).
- **Wiring**: root README packages table + provider chart, `packages/airhorn/README.md` provider chart, `AGENTS.md` package list, `site/docula.config.ts` docs page, root `publish:pingram` script, and a release workflow publish step.

## Note for the first release

`@airhornjs/pingram` has never been published, and npm Trusted Publishing (OIDC) can only be configured for packages that already exist on the registry. The new publish step is intentionally placed **last** in `release.yml` so a first-publish failure can't block the existing packages. Before the next release, a one-time manual `npm publish` from `packages/pingram` (then configuring the trusted publisher on npmjs.com) is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXHDyVjPeesdaHE5SsC9FN