### PR TITLE
ci: gate release on a test/build job and add deployment environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,19 +5,53 @@ on:
   release:
     types: [released]
 
-# Packages are published with npm Trusted Publishing (OIDC) — no NPM_TOKEN.
-# This requires a trusted publisher (this repository + this workflow file) to be
-# configured for each package on npmjs.com. The `id-token: write` permission lets
-# the job mint the short-lived OIDC token used for authentication and to sign the
-# provenance attestations.
 permissions:
   contents: read
-  id-token: write
 
 jobs:
-  setup-build-release:
+  setup-test-build:
 
     runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Testing
+        run: pnpm test:ci
+
+  setup-release:
+
+    needs: setup-test-build
+
+    runs-on: ubuntu-latest
+
+    # Packages are published with npm Trusted Publishing (OIDC) — no NPM_TOKEN.
+    # This requires a trusted publisher (this repository + this workflow file) to be
+    # configured for each package on npmjs.com. The `id-token: write` permission lets
+    # the job mint the short-lived OIDC token used for authentication and to sign the
+    # provenance attestations.
+    permissions:
+      contents: read
+      id-token: write
+
+    # A named environment records this publish as a tracked deployment, so the run
+    # shows a progress bar and the deployment history on the repo's Environments tab.
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/airhorn
 
     steps:
       - uses: actions/checkout@v6
@@ -35,9 +69,6 @@ jobs:
 
       - name: Build
         run: pnpm build
-
-      - name: Testing
-        run: pnpm test:ci
 
       - name: Publish airhorn
         run: pnpm publish:airhorn


### PR DESCRIPTION
This reorders the `release` workflow so publishing only happens after a dedicated test-and-build job passes, and surfaces the publish as a tracked deployment.

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A: CI workflow-only change, no application code touched.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

CI / workflow change to `.github/workflows/release.yml`:

- **Test/build runs first.** Split the single `setup-build-release` job into a `setup-test-build` job (install → `pnpm build` → `pnpm test:ci`) that runs before anything is published.
- **Release runs after.** The `setup-release` job declares `needs: setup-test-build`, so publishing only starts once test and build succeed; a failure in either short-circuits the release.
- **Deployment environment for the progress bar.** `setup-release` now sets `environment: { name: npm, url: https://www.npmjs.com/package/airhorn }`, so the run records a tracked deployment — GitHub shows the progress bar in the run summary and a history entry on the repo's Environments tab.
- **Least-privilege permissions.** Moved `id-token: write` (needed for npm Trusted Publishing / OIDC provenance) onto the publish job only; the workflow default is now `contents: read`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KfFfbfFHX9YQdkH7vYUbiY

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfFfbfFHX9YQdkH7vYUbiY)_