### PR TITLE
release: v7.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airhorn-mono",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Cloud Notification Library",
   "repository": "https://github.com/jaredwray/airhorn.git",
   "author": "Jared Wray <me@jaredwray.com>",

--- a/packages/airhorn/package.json
+++ b/packages/airhorn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airhorn",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Cloud Notification Library",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airhornjs/aws",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "AWS SNS and SES provider for Airhorn",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airhornjs/azure",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Azure provider for Airhorn",
   "license": "MIT",
   "author": "Jared Wray <me@jaredwray.com>",

--- a/packages/pingram/package.json
+++ b/packages/pingram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airhornjs/pingram",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Pingram provider for Airhorn",
   "license": "MIT",
   "author": "Jared Wray <me@jaredwray.com>",

--- a/packages/twilio/package.json
+++ b/packages/twilio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airhornjs/twilio",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Twilio SMS and SendGrid Email provider for Airhorn notification system",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release summary

Releasing all 5 packages in lockstep: **airhorn@7.1.0**, **@airhornjs/aws@7.1.0**, **@airhornjs/azure@7.1.0**, **@airhornjs/pingram@7.1.0**, **@airhornjs/twilio@7.1.0** (minor). Adds the new `@airhornjs/pingram` provider (SMS, Email, Mobile Push) and refreshes runtime and build dependencies across the workspace. No breaking changes.

> Synced with `main` after #619 (release-workflow hardening) merged — that PR is now part of this release window. The version bump still touches only the 6 `version` fields, and `mergeable_state` is clean.

## Packages

| Package | Current | New | Bump | Rationale | Commits |
|---|---|---|---|---|---|
| `@airhornjs/pingram` | new (unpublished) | `7.1.0` | **minor** | new provider package — first release; sets the bump | 2 |
| `airhorn` | `7.0.0` | `7.1.0` | **minor** | lockstep; own changes: ecto 4.8.7→5.0.0 (internal major), cacheable, hookified, writr | 5 |
| `@airhornjs/aws` | `7.0.0` | `7.1.0` | **minor** | lockstep; own change: aws-sdk 3.1057→3.1076 | 1 |
| `@airhornjs/azure` | `7.0.0` | `7.1.0` | **minor** | lockstep; no own changes | 0 |
| `@airhornjs/twilio` | `7.0.0` | `7.1.0` | **minor** | lockstep; no own changes | 0 |
| `airhorn-mono` (root) | `7.0.0` | `7.1.0` | _private_ | not published; version synced for lockstep; tooling (biome, vitest, tsx, tsdown, docula, pnpm) | 4 |

This is a fixed/locked-version monorepo — `release.yml` publishes all packages together and `scripts/version-sync.ts` drives every manifest from the root version, so the highest bump (minor, from the new pingram provider) applies to every package.

## airhorn v7.1.0 — 2026-07-02

Adds the new `@airhornjs/pingram` provider (SMS, Email, Mobile Push) and refreshes runtime and build dependencies across the workspace. No breaking changes.

### Features
- **New provider `@airhornjs/pingram`** — send SMS, Email, and Mobile Push through [Pingram](https://www.pingram.io) with a single API key, plus typed provider-level `sendDefaults` (`templateId`, `parameters`, `schedule`, and channel content defaults) that merge beneath message-derived values (#618)

  ```ts
  import { Airhorn, AirhornSendType } from 'airhorn';
  import { AirhornPingram } from '@airhornjs/pingram';

  const airhorn = new Airhorn({
    providers: [new AirhornPingram({ apiKey: 'pingram_sk_...', region: 'us' })],
  });

  // One API key covers SMS, Email, and Mobile Push
  await airhorn.send(
    '+16175551212',                                      // to (E.164)
    { from: '+1234567890', content: 'Order shipped!' },  // template
    {},                                                  // template data
    AirhornSendType.SMS,
  );
  ```

### Dependencies
**airhorn**
- `ecto` `^4.8.7` → `^5.0.0` (#617) — ecto's major is internal; airhorn's public API and `>=22.18.0` engine floor are unchanged, so no consumer action is required
- `cacheable` `^2.3.5` → `^2.5.0` (#616)
- `hookified` `^3.0.0` → `^3.0.1` (#613)
- `writr` `^6.1.2` → `^6.1.3` (#615)

**@airhornjs/aws**
- `@aws-sdk/client-ses` & `@aws-sdk/client-sns` `^3.1057.0` → `^3.1076.0` (#612)

### Internal
- Upgrade monorepo tooling: pnpm `11.5.0` → `11.9.0` (#614), docula `2.0.0` → `2.1.0` (#611), tsx `4.22.3` → `4.22.4` + tsdown `0.22.1` → `0.22.3` (#610), biome `2.4.16` → `2.5.1` + vitest `4.1.7` → `4.1.9` (#609)
- Harden the release pipeline: gate publishing on a `setup-test-build` job (install/build/test:ci) that `setup-release` now `needs`, scope `id-token: write` to the publish job, and add an `npm` deployment environment (#619)

### Contributors
- @jaredwray (11 PRs)

### Full List of Changes
- mono - chore: upgrade code quality dependencies by @jaredwray in #609
- mono - chore: upgrade TypeScript and build tooling by @jaredwray in #610
- mono - chore: upgrade docula by @jaredwray in #611
- aws - chore: upgrade AWS SDK dependencies by @jaredwray in #612
- airhorn - chore: upgrade hookified by @jaredwray in #613
- mono - chore: upgrade monorepo tooling (pnpm 11.9.0) by @jaredwray in #614
- airhorn - chore: upgrade writr by @jaredwray in #615
- airhorn - chore: upgrade cacheable by @jaredwray in #616
- airhorn - chore: upgrade ecto (breaking) by @jaredwray in #617
- pingram - feat: add @airhornjs/pingram provider for SMS, Email, and Mobile Push by @jaredwray in #618
- ci: gate release on a test/build job and add deployment environment by @jaredwray in #619

**Full diff:** https://github.com/jaredwray/airhorn/compare/v7.0.0...v7.1.0

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds (lockfile unchanged)
- [x] `pnpm build` succeeds for all 5 packages
- [x] `pnpm test:ci` passes locally — 174 tests, 100% line coverage (airhorn 80, pingram 30, azure 25, aws 23, twilio 16)
- [x] Branch synced with latest `main` (includes #619); PR diff is version-only and `mergeable_state` is clean
- [x] No uncommitted changes outside the version bump

## Post-merge
Publishing uses **npm Trusted Publishing (OIDC) with signed provenance** — no `NPM_TOKEN`. As of #619 the workflow runs a `setup-test-build` gate first, then the `setup-release` job publishes.

1. Merge this PR, then create a **GitHub Release at tag `v7.1.0`** ([`compare/v7.0.0...v7.1.0`](https://github.com/jaredwray/airhorn/compare/v7.0.0...v7.1.0)) using the notes above — `release.yml` builds, tests, and publishes `airhorn`, `@airhornjs/aws`, `@airhornjs/azure`, and `@airhornjs/twilio` to npm with provenance, and `deploy-site.yml` deploys the docs.
2. ⚠️ **`@airhornjs/pingram` first publish:** the package has never been published, and npm Trusted Publishing can only be configured for packages already on the registry. Its publish step is intentionally **last** in `release.yml` so a first-publish failure can't block the other four. Do a one-time manual publish from `packages/pingram` (`pnpm publish:pingram`, i.e. `pnpm publish --access public --provenance`), then configure its Trusted Publisher on npmjs.com (org/user `jaredwray`, repo `airhorn`, workflow `release.yml`) so future releases publish automatically.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYfqeatkw8aWn71TgMccz6)_