### PR TITLE
ci: make release.yml publish steps uniform now that pingram is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,11 +79,8 @@ jobs:
       - name: Publish @airhornjs/azure
         run: pnpm publish:azure
 
-      - name: Publish @airhornjs/twilio
-        run: pnpm publish:twilio
-
-      # Kept last: @airhornjs/pingram needs a one-time manual first publish
-      # before its npmjs.com trusted publisher can be configured, so a failure
-      # here must not block the packages above.
       - name: Publish @airhornjs/pingram
         run: pnpm publish:pingram
+
+      - name: Publish @airhornjs/twilio
+        run: pnpm publish:twilio


### PR DESCRIPTION
Now that `@airhornjs/pingram` has been published, its special-casing in the release workflow is obsolete. Pingram was previously kept last with an explanatory comment because it needed a one-time manual first publish before its npmjs.com trusted publisher could be configured — a failure there must not block the other packages. With pingram published, every package can follow the same pattern.

This change moves the pingram publish step into alphabetical order (between `azure` and `twilio`, matching the `publish:*` scripts in `package.json`) and drops the now-obsolete comment, so all five publish steps are uniform.

```diff
       - name: Publish @airhornjs/azure
         run: pnpm publish:azure

-      - name: Publish @airhornjs/twilio
-        run: pnpm publish:twilio
-
-      # Kept last: @airhornjs/pingram needs a one-time manual first publish
-      # before its npmjs.com trusted publisher can be configured, so a failure
-      # here must not block the packages above.
       - name: Publish @airhornjs/pingram
         run: pnpm publish:pingram
+
+      - name: Publish @airhornjs/twilio
+        run: pnpm publish:twilio
```

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A: this only touches the `release.yml` GitHub Actions workflow; no application code changed, so there is nothing to unit test.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

CI / build config cleanup — makes the `release.yml` publish steps uniform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWdQqHxV8ejW3ASNEMKVUj

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWdQqHxV8ejW3ASNEMKVUj)_