### PR TITLE
airhorn - chore: upgrade hookified

### DIFF
--- a/packages/airhorn/package.json
+++ b/packages/airhorn/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "cacheable": "^2.5.0",
     "ecto": "^5.0.0",
-    "hookified": "^3.0.1",
+    "hookified": "^3.0.2",
     "writr": "^6.1.3"
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       hookified:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
       writr:
         specifier: ^6.1.3
         version: 6.1.3
@@ -1852,8 +1852,8 @@ packages:
   hookified@2.2.0:
     resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
 
-  hookified@3.0.1:
-    resolution: {integrity: sha512-mtpUIV7U9reosQ16+OHWBd0Ca07fs1ryChQjBPuUMZnrRdLTCW+kEfkTcFudkaevp3gVe5H9FxDCBxYIdO+QQA==}
+  hookified@3.0.2:
+    resolution: {integrity: sha512-FpIcRHpFlW7yh68lmL0h1/Vodv77TogpHlt4qqakE/0RyQMjgNxs53acH9NJPeyRZutP7GnlqiyqRNejV8/lHQ==}
     engines: {node: '>=22.18.0'}
 
   html-dom-parser@8.0.0:
@@ -4397,7 +4397,7 @@ snapshots:
       '@jaredwray/fumanchu': 4.7.0
       cacheable: 2.5.0
       ejs: 6.0.1
-      hookified: 3.0.1
+      hookified: 3.0.2
       liquidjs: 10.27.0
       nunjucks: 3.2.4
       pug: 3.0.4
@@ -4636,7 +4636,7 @@ snapshots:
 
   hashery@3.0.0:
     dependencies:
-      hookified: 3.0.1
+      hookified: 3.0.2
 
   hasown@2.0.2:
     dependencies:
@@ -4758,7 +4758,7 @@ snapshots:
 
   hookified@2.2.0: {}
 
-  hookified@3.0.1: {}
+  hookified@3.0.2: {}
 
   html-dom-parser@8.0.0:
     dependencies:
@@ -6244,7 +6244,7 @@ snapshots:
       ai: 6.0.214(zod@4.4.3)
       cacheable: 2.5.0
       hashery: 3.0.0
-      hookified: 3.0.1
+      hookified: 3.0.2
       html-react-parser: 6.1.3(react@19.2.7)
       js-yaml: 4.3.0
       react: 19.2.7


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests pass with 100% code coverage — dependency-only change, no new tests needed; the existing suite passes unchanged.

**What kind of change does this PR introduce?**

Chore / dependency maintenance (runtime). First PR of the runtime phase. Upgrades the `hookified` runtime dependency in the `airhorn` core package:

- `hookified` 3.0.1 → 3.0.2

**Verification**
- [x] `pnpm build` passes (all 5 packages)
- [x] `pnpm test` passes locally on Node 22 — 240 tests green at 100% line coverage (airhorn 85, azure 25, aws 24, twilio 16, pingram 30). CI matrix covers Node 22 / 24 / 26.

---

Runtime phase begins. The dev phase is complete: code-quality (#624), build tooling (#625), and docula (#626) are merged. The **GitHub Actions** dev group was deferred — this sandbox's egress policy blocks the GitHub API (HTTP 403 for api.github.com / github.com) and the available GitHub tools are scoped to this repo, so the latest action majors can't be confirmed here (the workflows are already major-pinned to recent versions). **TypeScript 7** also remains deferred (tsconfig `moduleResolution` migration), and `@types/node` stays held at v24. Remaining runtime groups after this: writr, AWS SDK (ses + sns), pingram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xmD9VZRutXZvS6eeTAhBp

---
_Generated by [Claude Code](https://claude.ai/code/session_014xmD9VZRutXZvS6eeTAhBp)_