### PR TITLE
release: v7.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airhorn-mono",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "description": "Cloud Notification Library",
   "repository": "https://github.com/jaredwray/airhorn.git",
   "author": "Jared Wray <me@jaredwray.com>",

--- a/packages/airhorn/package.json
+++ b/packages/airhorn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airhorn",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "description": "Cloud Notification Library",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airhornjs/aws",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "description": "AWS SNS and SES provider for Airhorn",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airhornjs/azure",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "description": "Azure provider for Airhorn",
   "license": "MIT",
   "author": "Jared Wray <me@jaredwray.com>",

--- a/packages/pingram/package.json
+++ b/packages/pingram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airhornjs/pingram",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "description": "Pingram provider for Airhorn",
   "license": "MIT",
   "author": "Jared Wray <me@jaredwray.com>",

--- a/packages/twilio/package.json
+++ b/packages/twilio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airhornjs/twilio",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "description": "Twilio SMS and SendGrid Email provider for Airhorn notification system",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests pass with 100% code coverage — version-bump-only change; the existing suite passes unchanged.

**What kind of change does this PR introduce?**

Release — cuts **v7.1.2**, a dependency-maintenance patch. Version-only bump across all packages (no source changes).

## Release summary

Releasing all packages in lockstep: `airhorn`, `@airhornjs/aws`, `@airhornjs/azure`, `@airhornjs/pingram`, `@airhornjs/twilio` → **7.1.2** (patch). Fixed-version monorepo; the whole repo moves together via `version:sync`.

## Packages

| Package | Current | New | Bump | Rationale | Commits |
|---|---|---|---|---|---|
| `airhorn` | 7.1.1 | 7.1.2 | **patch** | runtime deps bumped (hookified, writr) | 2 |
| `@airhornjs/aws` | 7.1.1 | 7.1.2 | **patch** | runtime deps bumped (AWS SDK ses + sns) | 1 |
| `@airhornjs/pingram` | 7.1.1 | 7.1.2 | **patch** | runtime dep bumped (pingram); republish fixes npm gap (7.1.0 → 7.1.2) | 1 |
| `@airhornjs/azure` | 7.1.1 | 7.1.2 | **patch** | fixed-version lockstep (no direct change) | 0 |
| `@airhornjs/twilio` | 7.1.1 | 7.1.2 | **patch** | fixed-version lockstep (no direct change) | 0 |
| `airhorn-mono` (root) | 7.1.1 | 7.1.2 | _private_ | not published; version-synced | 8 |

## v7.1.2 — 2026-08-01

Dependency-maintenance patch across all packages: refreshes runtime and dev dependencies and makes the release workflow's publish steps uniform. No API or behavior changes.

### Internal
- upgrade code quality dependencies: @biomejs/biome 2.5.1→2.5.6, vitest & @vitest/coverage-v8 4.1.9→4.1.10 (140fa0e, #624)
- upgrade tsdown 0.22.3→0.22.14 and tsx 4.22.4→4.23.1 build tooling (945ab57, #625)
- upgrade docula 2.1.0→2.2.0 (5ef1297, #626)
- upgrade hookified 3.0.1→3.0.2 — `airhorn` runtime dep (eabf4f0, #627)
- upgrade writr 6.1.3→6.1.5 — `airhorn` runtime dep (b0ec808, #628)
- upgrade @aws-sdk/client-ses & @aws-sdk/client-sns 3.1076.0→3.1099.0 — `@airhornjs/aws` runtime deps (c713281, #629)
- upgrade pingram 1.0.14→1.0.16 — `@airhornjs/pingram` runtime dep (c9e9639, #630)
- make release.yml publish steps uniform now that pingram is published (60803d0, #623)

### Contributors
- @jaredwray (8)

### Full List of Changes
- ci: make release.yml publish steps uniform now that pingram is published by @jaredwray in #623
- mono - chore: upgrade code quality dependencies by @jaredwray in #624
- mono - chore: upgrade tsdown and tsx build tooling by @jaredwray in #625
- mono - chore: upgrade docula by @jaredwray in #626
- airhorn - chore: upgrade hookified by @jaredwray in #627
- airhorn - chore: upgrade writr by @jaredwray in #628
- aws - chore: upgrade AWS SDK dependencies by @jaredwray in #629
- pingram - chore: upgrade pingram by @jaredwray in #630

**Full diff:** https://github.com/jaredwray/airhorn/compare/v7.1.1...v7.1.2

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds (lockfile unchanged by the bump — workspace cross-deps)
- [x] `pnpm build` succeeds (all 5 packages)
- [x] `pnpm test:ci` passes locally on Node 22 — 240 tests, 100% coverage
- [x] No uncommitted changes outside the version bump (6 `package.json` version fields only)

## Post-merge
- Merge, then create a **GitHub Release at tag `v7.1.2`** — the `release.yml` workflow (`on: release`) builds, tests, and publishes all 5 packages to npm via Trusted Publishing (OIDC). This also republishes `@airhornjs/pingram`, currently stuck at 7.1.0 on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xmD9VZRutXZvS6eeTAhBp

---
_Generated by [Claude Code](https://claude.ai/code/session_014xmD9VZRutXZvS6eeTAhBp)_