### PR TITLE
Allow workerd build scripts to fix Cloudflare Pages deploy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ packages:
   - packages/*
 allowBuilds:
   esbuild: true
+  workerd: true


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A: this is a one-line CI/deploy configuration change with no library code affected; verified by reproducing the failing `pnpm add wrangler@4` step locally (fails with the original config, succeeds with this change).

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix for the `deploy-site` workflow.

The Cloudflare Pages deploy fails during `cloudflare/wrangler-action@v4`'s wrangler installation step:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: workerd@1.20260730.1
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
Error: The process '.../pnpm' failed with exit code 1
```

The action runs `pnpm add wrangler@4`, and wrangler depends on `workerd`, whose postinstall script is not in the `allowBuilds` allowlist in `pnpm-workspace.yaml` (only `esbuild` is approved). Under pnpm 11 the ignored build script is a hard error, so the install exits 1 and the deploy never runs.

This PR adds `workerd: true` to `allowBuilds`, alongside the existing `esbuild` entry.

Verified locally with pnpm 11.9.0 by running the action's exact install step at the repo root:
- Original config: `pnpm add wrangler@4` fails with `ERR_PNPM_IGNORED_BUILDS: workerd@1.20260730.1` (same as CI).
- With this change: install succeeds (`workerd postinstall: Done`, exit 0) and `pnpm exec wrangler --version` reports 4.116.0.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnoQNqbsePPatGkLhN39pK)_